### PR TITLE
Make keyboard shortcuts more sane

### DIFF
--- a/src/irust.rs
+++ b/src/irust.rs
@@ -85,11 +85,14 @@ impl IRust {
                     InputEvent::Keyboard(KeyEvent::Backspace) => {
                         self.handle_backspace()?;
                     }
+                    InputEvent::Keyboard(KeyEvent::Ctrl('c')) => {
+                        self.handle_ctrl_c()?;
+                    }
                     InputEvent::Keyboard(KeyEvent::Ctrl('d')) => {
-                        self.exit()?;
+                        self.handle_ctrl_d()?;
                     }
                     InputEvent::Keyboard(KeyEvent::Ctrl('z')) => {
-                        self.stop()?;
+                        self.handle_ctrl_z()?;
                     }
                     InputEvent::Keyboard(KeyEvent::Ctrl('l')) => {
                         self.clear()?;

--- a/src/irust/events.rs
+++ b/src/irust/events.rs
@@ -87,23 +87,44 @@ impl IRust {
         Ok(())
     }
 
-    pub fn exit(&mut self) -> std::io::Result<()> {
+    fn exit(&mut self) -> std::io::Result<()> {
+        self.terminal.clear(ClearType::All)?;
+        self.terminal.exit();
+
+        Ok(())
+    }
+
+    pub fn handle_ctrl_c(&mut self) -> std::io::Result<()> {
         if self.buffer.is_empty() {
-            self.terminal.clear(ClearType::All)?;
-            self.terminal.exit();
+            self.exit()?;
+        } else {
+            self.buffer.clear();
+            self.write_newline()?;
+            self.write_in()?;
         }
 
         Ok(())
     }
 
-    pub fn stop(&mut self) -> std::io::Result<()> {
+    pub fn handle_ctrl_d(&mut self) -> std::io::Result<()> {
+        if self.buffer.is_empty() {
+            self.exit()?;
+        }
+
+        Ok(())
+    }
+
+    pub fn handle_ctrl_z(&mut self) -> std::io::Result<()> {
         #[cfg(target_family = "unix")]
         {
+            use nix::{
+                sys::signal::{kill, Signal},
+                unistd::Pid,
+            };
             self.terminal.clear(ClearType::All)?;
-            let _ = nix::sys::signal::kill(
-                nix::unistd::Pid::this(),
-                Some(nix::sys::signal::Signal::SIGTSTP),
-            );
+            let _ = kill(Pid::this(), Some(Signal::SIGTSTP));
+
+            // display empty prompt after SIGCONT
             self.clear()?;
         }
 


### PR DESCRIPTION
Related: #1 

Now irust behaves similarly to Python, bash and Node.js. The only difference is in `Ctrl+C`: Python and bash cannot be closed by Ctrl+C, while Node.js uses triple Ctrl+C (first one clears line, 2 next closes REPL). I find double Ctrl+C the most sane (first one clears line, second closes REPL).