### PR TITLE
Better error messages

### DIFF
--- a/src/irust/events.rs
+++ b/src/irust/events.rs
@@ -34,7 +34,7 @@ impl IRust {
             }
             Err(e) => {
                 self.printer = Printer::new(PrinterItem::new(
-                    e.description().to_string(),
+                    e.to_string(),
                     PrinterItemType::Err,
                 ));
                 self.printer.add_new_line(1);


### PR DESCRIPTION
```text
In: std::process::Command::new("").output().unwrap_err().description().to_string()
Out: "entity not found"


In: std::process::Command::new("").output().unwrap_err().to_string()
Out: "No such file or directory (os error 2)"
```