### PR TITLE
[WIP] Refactor `Cursor` struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**0.6.13**
+- Use `chars_count` instead of `len` to handle special chars
+
 **0.6.12**
 - Fix line end detection
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**0.6.14**
+- Fix scrolling bug
+- Improve highlight fn (using lazy evaluation)
+
 **0.6.13**
 - Use `chars_count` instead of `len` to handle special chars
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "irust"
-version = "0.6.13"
+version = "0.6.14"
 authors = ["Nbiba Bedis <bedisnbiba@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "irust"
-version = "0.6.12"
+version = "0.6.13"
 authors = ["Nbiba Bedis <bedisnbiba@gmail.com>"]
 edition = "2018"
 readme = "README.md"

--- a/src/irust.rs
+++ b/src/irust.rs
@@ -1,5 +1,5 @@
 use crossterm::{
-    Crossterm, InputEvent, KeyEvent, Terminal, TerminalColor, TerminalCursor, TerminalInput,
+    Crossterm, InputEvent, KeyEvent, Terminal, TerminalColor, TerminalInput,
 };
 
 mod art;
@@ -32,14 +32,13 @@ const IN: &str = "In: ";
 const OUT: &str = "Out: ";
 
 pub struct IRust {
-    cursor: TerminalCursor,
     terminal: Terminal,
     input: TerminalInput,
     printer: Printer,
     color: TerminalColor,
     buffer: String,
     repl: Repl,
-    internal_cursor: Cursor,
+    cursor: Cursor,
     history: History,
     options: Options,
     racer: Result<Racer, IRustError>,
@@ -50,7 +49,7 @@ pub struct IRust {
 impl IRust {
     pub fn new() -> Self {
         let crossterm = Crossterm::new();
-        let cursor = crossterm.cursor();
+        let internal_cursor = crossterm.cursor();
         let terminal = crossterm.terminal();
         let input = crossterm.input();
         let printer = Printer::default();
@@ -69,7 +68,7 @@ impl IRust {
             let (width, height) = terminal.terminal_size();
             (width as usize, height as usize)
         };
-        let internal_cursor = Cursor::new(0, 0, size.0);
+        let cursor = Cursor::new(internal_cursor, 0, 0, size.0);
 
         IRust {
             cursor,
@@ -81,7 +80,6 @@ impl IRust {
             repl,
             history,
             options,
-            internal_cursor,
             racer,
             debouncer,
             size,

--- a/src/irust/art.rs
+++ b/src/irust/art.rs
@@ -9,7 +9,7 @@ impl IRust {
         mut add_cmd: std::process::Child,
         msg: &str,
     ) -> Result<(), IRustError> {
-        self.cursor.hide()?;
+        self.cursor.hide();
         self.color.set_fg(Color::Cyan)?;
 
         match self.wait_add_inner(&mut add_cmd, msg) {
@@ -60,9 +60,9 @@ impl IRust {
     }
 
     fn clean_art(&mut self) -> Result<(), IRustError> {
-        self.reset_cursor_position()?;
+        self.cursor.reset_cursor_position()?;
         self.write_newline()?;
-        self.cursor.show()?;
+        self.cursor.show();
         self.color.reset()?;
         Ok(())
     }
@@ -75,7 +75,7 @@ impl IRust {
         self.printer.add_new_line(2);
 
         self.write_out()?;
-        self.internal_cursor.add_bounds();
+        self.cursor.add_bounds();
 
         Ok(())
     }

--- a/src/irust/events.rs
+++ b/src/irust/events.rs
@@ -132,7 +132,7 @@ impl IRust {
             )?;
             self.terminal.clear(ClearType::FromCursorDown)?;
             self.buffer = up.clone();
-            self.cursor.buffer_pos = self.buffer.len();
+            self.cursor.buffer_pos = StringTools::chars_count(&self.buffer);
 
             let overflow = self.cursor.screen_height_overflow_by_str(&self, &up);
 
@@ -159,7 +159,7 @@ impl IRust {
             )?;
             self.terminal.clear(ClearType::FromCursorDown)?;
             self.buffer = down.clone();
-            self.cursor.buffer_pos = self.buffer.len();
+            self.cursor.buffer_pos = StringTools::chars_count(&self.buffer);
 
             let overflow = self.cursor.screen_height_overflow_by_str(&self, &down);
 
@@ -284,7 +284,7 @@ impl IRust {
             let distance_to_end = {
                 let c1 =
                     self.cursor.current_bounds_mut().1 - self.cursor.screen_pos.0;
-                let c2 = self.buffer.len() - self.cursor.buffer_pos;
+                let c2 = StringTools::chars_count(&self.buffer) - self.cursor.buffer_pos;
                 std::cmp::min(c1, c2)
             };
             if distance_to_end != 0 {

--- a/src/irust/highlight.rs
+++ b/src/irust/highlight.rs
@@ -1,20 +1,21 @@
 use super::printer::{Printer, PrinterItem, PrinterItemType};
+use once_cell::sync::Lazy;
 use syntect::easy::HighlightLines;
 use syntect::highlighting::{Color, ThemeSet};
-use syntect::parsing::SyntaxSet;
+use syntect::parsing::{SyntaxReference, SyntaxSet};
 use syntect::util::LinesWithEndings;
 
-pub fn highlight(c: &str) -> Printer {
-    let ps = SyntaxSet::load_defaults_newlines();
-    let ts = ThemeSet::load_defaults();
+static PS: Lazy<SyntaxSet> = Lazy::new(SyntaxSet::load_defaults_newlines);
+static TS: Lazy<ThemeSet> = Lazy::new(ThemeSet::load_defaults);
+static SYNTAX: Lazy<&SyntaxReference> = Lazy::new(|| PS.find_syntax_by_extension("rs").unwrap());
 
-    let syntax = ps.find_syntax_by_extension("rs").unwrap();
-    let mut h = HighlightLines::new(syntax, &ts.themes["base16-ocean.dark"]);
+pub fn highlight(c: &str) -> Printer {
+    let mut h = HighlightLines::new(&SYNTAX, &TS.themes["base16-ocean.dark"]);
 
     let mut printer = Printer::default();
 
     for line in LinesWithEndings::from(c) {
-        h.highlight(line, &ps)
+        h.highlight(line, &PS)
             .into_iter()
             .for_each(|(style, part)| {
                 let fg_color = match style.foreground {

--- a/src/irust/parser.rs
+++ b/src/irust/parser.rs
@@ -74,7 +74,7 @@ impl IRust {
             .map(ToOwned::to_owned)
             .collect();
 
-        self.save_cursor_position()?;
+        self.cursor.save_cursor_position()?;
         self.wait_add(self.repl.add_dep(&dep)?, "Add")?;
         self.wait_add(self.repl.build()?, "Build")?;
         self.write_newline()?;

--- a/src/irust/printer.rs
+++ b/src/irust/printer.rs
@@ -140,15 +140,15 @@ impl IRust {
     }
 
     pub fn write_in(&mut self) -> Result<(), IRustError> {
-        self.internal_cursor.screen_pos.0 = 0;
-        self.goto_cursor()?;
+        self.cursor.screen_pos.0 = 0;
+        self.cursor.goto_cursor()?;
         self.terminal.clear(ClearType::FromCursorDown)?;
         self.color.set_fg(self.options.input_color)?;
         self.write(IN)?;
         //self.internal_cursor.screen_pos.0 = 4;
-        *self.internal_cursor.current_bounds_mut() = (4, self.size.0);
-        self.internal_cursor.buffer_pos = 0;
-        self.internal_cursor.lock_pos = (4, self.internal_cursor.screen_pos.1);
+        *self.cursor.current_bounds_mut() = (4, self.size.0);
+        self.cursor.buffer_pos = 0;
+        self.cursor.lock_pos = (4, self.cursor.screen_pos.1);
         self.color.reset()?;
         Ok(())
     }
@@ -168,18 +168,18 @@ impl IRust {
 
         // If the new character is not in the last position
         // rewrite the buffer from the character and on
-        if !self.at_line_end() {
-            self.save_cursor_position()?;
+        if !self.cursor.is_at_line_end(&self) {
+            self.cursor.save_cursor_position()?;
             for character in self
                 .buffer
                 .chars()
-                .skip(self.internal_cursor.buffer_pos)
+                .skip(self.cursor.buffer_pos)
                 .collect::<Vec<char>>()
                 .iter()
             {
                 self.write(&character.to_string())?;
             }
-            self.reset_cursor_position()?;
+            self.cursor.reset_cursor_position()?;
         }
 
         // Reset color

--- a/src/irust/racer.rs
+++ b/src/irust/racer.rs
@@ -361,7 +361,7 @@ impl IRust {
             StringTools::strings_unique(&self.buffer, &mut suggestion);
 
             self.buffer.push_str(&suggestion);
-            self.cursor.buffer_pos = self.buffer.len();
+            self.cursor.buffer_pos = StringTools::chars_count(&self.buffer);
 
             // clear screen from cursor down
             self.terminal.clear(ClearType::FromCursorDown)?;

--- a/src/irust/writer.rs
+++ b/src/irust/writer.rs
@@ -15,7 +15,7 @@ impl IRust {
             } else {
                 out.chars().for_each(|c| {
                     let _ = self.terminal.write(c);
-                    let _ = self.move_cursor_right();
+                    let _ = self.cursor.move_right();
                 });
             }
         }
@@ -34,28 +34,29 @@ impl IRust {
         x: P,
         y: U,
     ) -> Result<(), IRustError> {
-        self.move_cursor_to(x, y)?;
+        self.cursor.move_cursor_to(x, y)?;
         self.terminal.write(s)?;
         Ok(())
     }
 
     pub fn write_newline(&mut self) -> Result<(), IRustError> {
-        self.internal_cursor.screen_pos.0 = 0;
-        self.internal_cursor.screen_pos.1 += 1;
-        self.internal_cursor.add_bounds();
+        self.cursor.screen_pos.0 = 0;
+        self.cursor.screen_pos.1 += 1;
+        self.cursor.add_bounds();
         // y should never exceed screen height
-        if self.internal_cursor.screen_pos.1 == self.size.1 {
+        if self.cursor.screen_pos.1 == self.size.1 {
             self.scroll_up(1);
         }
-        self.goto_cursor()?;
+
+        self.cursor.goto_cursor()?;
         Ok(())
     }
 
     pub fn clear_suggestion(&mut self) -> Result<(), IRustError> {
-        if self.at_line_end() {
+        if self.cursor.is_at_line_end(&self) {
             self.clear_from(
-                self.internal_cursor.screen_pos.0,
-                self.internal_cursor.screen_pos.1,
+                self.cursor.screen_pos.0,
+                self.cursor.screen_pos.1,
             )?;
         }
 
@@ -67,30 +68,30 @@ impl IRust {
         x: P,
         y: U,
     ) -> Result<(), IRustError> {
-        self.cursor.save_position()?;
-        self.move_cursor_to(x, y)?;
+        self.cursor.save_position();
+        self.cursor.move_cursor_to(x, y)?;
         self.terminal.clear(ClearType::FromCursorDown)?;
-        self.cursor.reset_position()?;
+        self.cursor.reset_position();
 
         Ok(())
     }
 
     pub fn clear(&mut self) -> Result<(), IRustError> {
         self.terminal.clear(ClearType::All)?;
-        self.internal_cursor.reset();
-        self.internal_cursor.screen_pos.1 = 0;
-        self.goto_cursor()?;
+        self.cursor.reset();
+        self.cursor.screen_pos.1 = 0;
+        self.cursor.goto_cursor()?;
 
         self.write_in()?;
         self.write(&self.buffer.clone())?;
-        self.internal_cursor.buffer_pos = self.buffer.len();
+        self.cursor.buffer_pos = StringTools::chars_count(&self.buffer);
 
         Ok(())
     }
 
     pub fn delete_char(&mut self) -> Result<(), IRustError> {
         if !self.buffer.is_empty() {
-            StringTools::remove_at_char_idx(&mut self.buffer, self.internal_cursor.buffer_pos);
+            StringTools::remove_at_char_idx(&mut self.buffer, self.cursor.buffer_pos);
         }
         self.write_insert(None)?;
         Ok(())
@@ -99,8 +100,8 @@ impl IRust {
     pub fn scroll_up(&mut self, n: usize) {
         self.terminal.scroll_up(n as i16).unwrap();
         self.cursor.move_up(n as u16);
-        self.internal_cursor.screen_pos.1 = self.internal_cursor.screen_pos.1.saturating_sub(n);
-        self.internal_cursor.lock_pos.1 = self.internal_cursor.lock_pos.1.saturating_sub(n);
-        self.internal_cursor.bounds.shift_keys_left(n);
+        self.cursor.screen_pos.1 = self.cursor.screen_pos.1.saturating_sub(n);
+        self.cursor.lock_pos.1 = self.cursor.lock_pos.1.saturating_sub(n);
+        self.cursor.bounds.shift_keys_left(n);
     }
 }


### PR DESCRIPTION
Currently, this does not quite work, but the general framework is there. The problem is printing the output (it doesn't work quite right), and I assume it's because of how `Clone` and the `reset` function for `Cursor` are implemented in this branch (can't clone the terminal cursor, so I've created a new one, which I don't think is working. Need a way to copy over/clone the current `TerminalCursor`).

Also, I may need to rebase with master: should be able to do so once I work out the conflicts.