### PR TITLE
Refactor `Cursor` struct

### DIFF
--- a/src/irust.rs
+++ b/src/irust.rs
@@ -1,5 +1,5 @@
 use crossterm::{
-    Crossterm, InputEvent, KeyEvent, Terminal, TerminalColor, TerminalCursor, TerminalInput,
+    Crossterm, InputEvent, KeyEvent, Terminal, TerminalColor, TerminalInput,
 };
 
 mod art;
@@ -32,14 +32,13 @@ const IN: &str = "In: ";
 const OUT: &str = "Out: ";
 
 pub struct IRust {
-    cursor: TerminalCursor,
     terminal: Terminal,
     input: TerminalInput,
     printer: Printer,
     color: TerminalColor,
     buffer: String,
     repl: Repl,
-    internal_cursor: Cursor,
+    cursor: Cursor,
     history: History,
     options: Options,
     racer: Result<Racer, IRustError>,
@@ -50,7 +49,6 @@ pub struct IRust {
 impl IRust {
     pub fn new() -> Self {
         let crossterm = Crossterm::new();
-        let cursor = crossterm.cursor();
         let terminal = crossterm.terminal();
         let input = crossterm.input();
         let printer = Printer::default();
@@ -69,7 +67,7 @@ impl IRust {
             let (width, height) = terminal.terminal_size();
             (width as usize, height as usize)
         };
-        let internal_cursor = Cursor::new(0, 0, size.0);
+        let cursor = Cursor::new(0, 0, size.0);
 
         IRust {
             cursor,
@@ -81,7 +79,6 @@ impl IRust {
             repl,
             history,
             options,
-            internal_cursor,
             racer,
             debouncer,
             size,

--- a/src/irust/art.rs
+++ b/src/irust/art.rs
@@ -9,7 +9,7 @@ impl IRust {
         mut add_cmd: std::process::Child,
         msg: &str,
     ) -> Result<(), IRustError> {
-        self.cursor.hide()?;
+        self.cursor.hide();
         self.color.set_fg(Color::Cyan)?;
 
         match self.wait_add_inner(&mut add_cmd, msg) {
@@ -60,9 +60,9 @@ impl IRust {
     }
 
     fn clean_art(&mut self) -> Result<(), IRustError> {
-        self.reset_cursor_position()?;
+        self.cursor.reset_position()?;
         self.write_newline()?;
-        self.cursor.show()?;
+        self.cursor.show();
         self.color.reset()?;
         Ok(())
     }
@@ -75,7 +75,7 @@ impl IRust {
         self.printer.add_new_line(2);
 
         self.write_out()?;
-        self.internal_cursor.add_bounds();
+        self.cursor.add_bounds();
 
         Ok(())
     }

--- a/src/irust/events.rs
+++ b/src/irust/events.rs
@@ -11,21 +11,21 @@ impl IRust {
         self.clear_suggestion()?;
 
         // check for scroll
-        if self.internal_cursor.screen_pos == (self.size.0, self.size.1 - 1) {
+        if self.cursor.pos.screen_pos == (self.size.0, self.size.1 - 1) {
             self.scroll_up(1);
         }
 
         // Insert input char in buffer
-        StringTools::insert_at_char_idx(&mut self.buffer, self.internal_cursor.buffer_pos, c);
+        StringTools::insert_at_char_idx(&mut self.buffer, self.cursor.pos.buffer_pos, c);
 
         // update histroy current
         self.history.update_current(&self.buffer);
 
         // advance buffer pos
-        self.internal_cursor.move_buffer_cursor_right();
+        self.cursor.move_buffer_cursor_right();
 
         // unbound upper limit
-        self.internal_cursor.current_bounds_mut().1 = self.size.0;
+        self.cursor.current_bounds_mut().1 = self.size.0;
 
         // Write input char
         self.write_insert(Some(&c.to_string()))?;
@@ -79,7 +79,7 @@ impl IRust {
     }
 
     fn incomplete_input(&self) -> bool {
-        self.at_line_end() && StringTools::unmatched_brackets(&self.buffer)
+        self.cursor.is_at_line_end(&self) && StringTools::unmatched_brackets(&self.buffer)
             || self
                 .buffer
                 .trim_end()
@@ -87,15 +87,15 @@ impl IRust {
     }
 
     fn handle_incomplete_input(&mut self) -> Result<(), IRustError> {
-        self.internal_cursor.current_bounds_mut().1 = self.internal_cursor.screen_pos.0 - 1;
-        self.internal_cursor.screen_pos.0 = 4;
-        self.internal_cursor.screen_pos.1 += 1;
-        if self.internal_cursor.screen_pos.1 == self.size.1 {
+        self.cursor.current_bounds_mut().1 = self.cursor.pos.screen_pos.0 - 1;
+        self.cursor.pos.screen_pos.0 = 4;
+        self.cursor.pos.screen_pos.1 += 1;
+        if self.cursor.pos.screen_pos.1 == self.size.1 {
             self.scroll_up(1);
         }
-        self.internal_cursor.add_bounds();
+        self.cursor.add_bounds();
 
-        self.goto_cursor()?;
+        self.cursor.goto_internal_pos()?;
         Ok(())
     }
 
@@ -125,16 +125,16 @@ impl IRust {
 
     pub fn handle_up(&mut self) -> Result<(), IRustError> {
         if let Some(up) = self.history.up() {
-            self.internal_cursor.reset_screen_cursor();
-            self.move_cursor_to(
-                self.internal_cursor.lock_pos.0,
-                self.internal_cursor.lock_pos.1,
+            self.cursor.reset_screen_cursor();
+            self.cursor.move_cursor_to(
+                self.cursor.pos.starting_pos.0,
+                self.cursor.pos.starting_pos.1,
             )?;
             self.terminal.clear(ClearType::FromCursorDown)?;
             self.buffer = up.clone();
-            self.internal_cursor.buffer_pos = StringTools::chars_count(&self.buffer);
+            self.cursor.pos.buffer_pos = StringTools::chars_count(&self.buffer);
 
-            let overflow = self.screen_height_overflow_by_str(&up);
+            let overflow = self.cursor.screen_height_overflow_by_str(&self, &up);
 
             if overflow != 0 {
                 self.scroll_up(overflow);
@@ -152,16 +152,16 @@ impl IRust {
         }
 
         if let Some(down) = self.history.down() {
-            self.internal_cursor.reset_screen_cursor();
-            self.move_cursor_to(
-                self.internal_cursor.lock_pos.0,
-                self.internal_cursor.lock_pos.1,
+            self.cursor.reset_screen_cursor();
+            self.cursor.move_cursor_to(
+                self.cursor.pos.starting_pos.0,
+                self.cursor.pos.starting_pos.1,
             )?;
             self.terminal.clear(ClearType::FromCursorDown)?;
             self.buffer = down.clone();
-            self.internal_cursor.buffer_pos = StringTools::chars_count(&self.buffer);
+            self.cursor.pos.buffer_pos = StringTools::chars_count(&self.buffer);
 
-            let overflow = self.screen_height_overflow_by_str(&down);
+            let overflow = self.cursor.screen_height_overflow_by_str(&self, &down);
 
             if overflow != 0 {
                 self.scroll_up(overflow);
@@ -176,17 +176,17 @@ impl IRust {
     pub fn handle_left(&mut self) -> Result<(), IRustError> {
         self.clear_suggestion()?;
 
-        if self.internal_cursor.buffer_pos > 0 {
-            self.move_cursor_left(Move::Free)?;
-            self.internal_cursor.move_buffer_cursor_left();
+        if self.cursor.pos.buffer_pos > 0 {
+            self.cursor.move_screen_cursor_left(Move::Free);
+            self.cursor.move_buffer_cursor_left();
         }
         Ok(())
     }
 
     pub fn handle_right(&mut self) -> Result<(), IRustError> {
-        if !self.at_line_end() {
-            self.move_cursor_right()?;
-            self.internal_cursor.move_buffer_cursor_right();
+        if !self.cursor.is_at_line_end(&self) {
+            self.cursor.move_screen_cursor_right();
+            self.cursor.move_buffer_cursor_right();
         } else {
             let _ = self.use_suggestion();
         }
@@ -194,9 +194,9 @@ impl IRust {
     }
 
     pub fn handle_backspace(&mut self) -> Result<(), IRustError> {
-        if self.internal_cursor.buffer_pos > 0 {
-            self.move_cursor_left(Move::Modify)?;
-            self.internal_cursor.move_buffer_cursor_left();
+        if self.cursor.pos.buffer_pos > 0 {
+            self.cursor.move_screen_cursor_left(Move::Modify);
+            self.cursor.move_buffer_cursor_left();
             self.delete_char()?;
             // update histroy current
             self.history.update_current(&self.buffer);
@@ -205,7 +205,7 @@ impl IRust {
     }
 
     pub fn handle_del(&mut self) -> Result<(), IRustError> {
-        if self.internal_cursor.buffer_pos > 0 {
+        if self.cursor.pos.buffer_pos > 1 {
             self.delete_char()?;
         }
         Ok(())
@@ -267,30 +267,30 @@ impl IRust {
     pub fn go_to_start(&mut self) -> Result<(), IRustError> {
         self.clear_suggestion()?;
         let distance_to_start =
-            self.internal_cursor.screen_pos.0 - self.internal_cursor.current_bounds_mut().0;
+            self.cursor.pos.screen_pos.0 - self.cursor.current_bounds_mut().0;
         if distance_to_start != 0 {
-            self.cursor.move_left(distance_to_start as u16);
-            self.internal_cursor.screen_pos.0 -= distance_to_start;
-            self.internal_cursor.buffer_pos -= distance_to_start;
+            self.cursor.move_left(distance_to_start as u16)?;
+            self.cursor.pos.screen_pos.0 -= distance_to_start;
+            self.cursor.pos.buffer_pos -= distance_to_start;
         }
 
         Ok(())
     }
 
     pub fn go_to_end(&mut self) -> Result<(), IRustError> {
-        if self.at_line_end() {
+        if self.cursor.is_at_line_end(&self) {
             let _ = self.use_suggestion();
         } else {
             let distance_to_end = {
                 let c1 =
-                    self.internal_cursor.current_bounds_mut().1 - self.internal_cursor.screen_pos.0;
-                let c2 = StringTools::chars_count(&self.buffer) - self.internal_cursor.buffer_pos;
+                    self.cursor.current_bounds_mut().1 - self.cursor.pos.screen_pos.0;
+                let c2 = StringTools::chars_count(&self.buffer) - self.cursor.pos.buffer_pos;
                 std::cmp::min(c1, c2)
             };
             if distance_to_end != 0 {
-                self.cursor.move_right(distance_to_end as u16);
-                self.internal_cursor.screen_pos.0 += distance_to_end;
-                self.internal_cursor.buffer_pos += distance_to_end;
+                self.cursor.move_right(distance_to_end as u16)?;
+                self.cursor.pos.screen_pos.0 += distance_to_end;
+                self.cursor.pos.buffer_pos += distance_to_end;
             }
         }
 
@@ -300,37 +300,37 @@ impl IRust {
     pub fn handle_ctrl_left(&mut self) -> Option<()> {
         let _ = self.clear_suggestion();
 
-        if self.internal_cursor.buffer_pos < 1 {
+        if self.cursor.pos.buffer_pos < 1 {
             return Some(());
         }
 
         let buffer = self.buffer.chars().collect::<Vec<char>>();
 
-        let _ = self.move_cursor_left(Move::Free);
-        self.internal_cursor.move_buffer_cursor_left();
+        let _ = self.cursor.move_screen_cursor_left(Move::Free);
+        self.cursor.move_buffer_cursor_left();
 
-        if let Some(current_char) = buffer.get(self.internal_cursor.buffer_pos.checked_sub(1)?) {
+        if let Some(current_char) = buffer.get(self.cursor.pos.buffer_pos.checked_sub(1)?) {
             match *current_char {
                 ' ' => {
-                    while buffer[self.internal_cursor.buffer_pos] == ' ' {
-                        let _ = self.move_cursor_left(Move::Free);
-                        self.internal_cursor.move_buffer_cursor_left();
+                    while buffer[self.cursor.pos.buffer_pos] == ' ' {
+                        let _ = self.cursor.move_screen_cursor_left(Move::Free);
+                        self.cursor.move_buffer_cursor_left();
                     }
                 }
                 c if c.is_alphanumeric() => {
-                    while buffer[self.internal_cursor.buffer_pos.checked_sub(1)?].is_alphanumeric()
+                    while buffer[self.cursor.pos.buffer_pos.checked_sub(1)?].is_alphanumeric()
                     {
-                        let _ = self.move_cursor_left(Move::Free);
-                        self.internal_cursor.move_buffer_cursor_left();
+                        let _ = self.cursor.move_screen_cursor_left(Move::Free);
+                        self.cursor.move_buffer_cursor_left();
                     }
                 }
 
                 _ => {
-                    while !buffer[self.internal_cursor.buffer_pos.checked_sub(1)?].is_alphanumeric()
-                        && buffer[self.internal_cursor.buffer_pos.checked_sub(1)?] != ' '
+                    while !buffer[self.cursor.pos.buffer_pos.checked_sub(1)?].is_alphanumeric()
+                        && buffer[self.cursor.pos.buffer_pos.checked_sub(1)?] != ' '
                     {
-                        let _ = self.move_cursor_left(Move::Free);
-                        self.internal_cursor.move_buffer_cursor_left();
+                        let _ = self.cursor.move_screen_cursor_left(Move::Free);
+                        self.cursor.move_buffer_cursor_left();
                     }
                 }
             }
@@ -340,39 +340,39 @@ impl IRust {
 
     pub fn handle_ctrl_right(&mut self) {
         let buffer = self.buffer.chars().collect::<Vec<char>>();
-        if !self.at_line_end() {
-            let _ = self.move_cursor_right();
-            self.internal_cursor.move_buffer_cursor_right();
+        if !self.cursor.is_at_line_end(&self) {
+            let _ = self.cursor.move_screen_cursor_right();
+            self.cursor.move_buffer_cursor_right();
         } else {
             let _ = self.use_suggestion();
         }
-        if let Some(current_char) = buffer.get(self.internal_cursor.buffer_pos) {
+        if let Some(current_char) = buffer.get(self.cursor.pos.buffer_pos) {
             match *current_char {
                 ' ' => {
-                    while buffer.get(self.internal_cursor.buffer_pos + 1) == Some(&' ') {
-                        let _ = self.move_cursor_right();
-                        self.internal_cursor.move_buffer_cursor_right();
+                    while buffer.get(self.cursor.pos.buffer_pos + 1) == Some(&' ') {
+                        let _ = self.cursor.move_screen_cursor_right();
+                        self.cursor.move_buffer_cursor_right();
                     }
-                    let _ = self.move_cursor_right();
-                    self.internal_cursor.move_buffer_cursor_right();
+                    let _ = self.cursor.move_screen_cursor_right();
+                    self.cursor.move_buffer_cursor_right();
                 }
                 c if c.is_alphanumeric() => {
-                    while let Some(character) = buffer.get(self.internal_cursor.buffer_pos) {
+                    while let Some(character) = buffer.get(self.cursor.pos.buffer_pos) {
                         if !character.is_alphanumeric() {
                             break;
                         }
-                        let _ = self.move_cursor_right();
-                        self.internal_cursor.move_buffer_cursor_right();
+                        let _ = self.cursor.move_screen_cursor_right();
+                        self.cursor.move_buffer_cursor_right();
                     }
                 }
 
                 _ => {
-                    while let Some(character) = buffer.get(self.internal_cursor.buffer_pos) {
+                    while let Some(character) = buffer.get(self.cursor.pos.buffer_pos) {
                         if character.is_alphanumeric() || *character == ' ' {
                             break;
                         }
-                        let _ = self.move_cursor_right();
-                        self.internal_cursor.move_buffer_cursor_right();
+                        let _ = self.cursor.move_screen_cursor_right();
+                        self.cursor.move_buffer_cursor_right();
                     }
                 }
             }

--- a/src/irust/parser.rs
+++ b/src/irust/parser.rs
@@ -74,7 +74,7 @@ impl IRust {
             .map(ToOwned::to_owned)
             .collect();
 
-        self.save_cursor_position()?;
+        self.cursor.save_position()?;
         self.wait_add(self.repl.add_dep(&dep)?, "Add")?;
         self.wait_add(self.repl.build()?, "Build")?;
         self.write_newline()?;

--- a/src/irust/printer.rs
+++ b/src/irust/printer.rs
@@ -140,15 +140,15 @@ impl IRust {
     }
 
     pub fn write_in(&mut self) -> Result<(), IRustError> {
-        self.internal_cursor.screen_pos.0 = 0;
-        self.goto_cursor()?;
+        self.cursor.pos.screen_pos.0 = 0;
+        self.cursor.goto_internal_pos()?;
         self.terminal.clear(ClearType::FromCursorDown)?;
         self.color.set_fg(self.options.input_color)?;
         self.write(IN)?;
         //self.internal_cursor.screen_pos.0 = 4;
-        *self.internal_cursor.current_bounds_mut() = (4, self.size.0);
-        self.internal_cursor.buffer_pos = 0;
-        self.internal_cursor.lock_pos = (4, self.internal_cursor.screen_pos.1);
+        *self.cursor.current_bounds_mut() = (4, self.size.0);
+        self.cursor.pos.buffer_pos = 0;
+        self.cursor.pos.starting_pos = (4, self.cursor.pos.screen_pos.1);
         self.color.reset()?;
         Ok(())
     }
@@ -168,18 +168,18 @@ impl IRust {
 
         // If the new character is not in the last position
         // rewrite the buffer from the character and on
-        if !self.at_line_end() {
-            self.save_cursor_position()?;
+        if !self.cursor.is_at_line_end(&self) {
+            self.cursor.save_position()?;
             for character in self
                 .buffer
                 .chars()
-                .skip(self.internal_cursor.buffer_pos)
+                .skip(self.cursor.pos.buffer_pos)
                 .collect::<Vec<char>>()
                 .iter()
             {
                 self.write(&character.to_string())?;
             }
-            self.reset_cursor_position()?;
+            self.cursor.reset_position()?;
         }
 
         // Reset color

--- a/src/irust/racer.rs
+++ b/src/irust/racer.rs
@@ -157,7 +157,7 @@ impl Racer {
 impl IRust {
     pub fn update_suggestions(&mut self) -> Result<(), IRustError> {
         // return if we're not at the end of the line
-        if !self.at_line_end() {
+        if !self.cursor.is_at_line_end(&self) {
             return Ok(());
         }
 
@@ -224,27 +224,27 @@ impl IRust {
 
     fn write_current_suggestion(&mut self) -> Result<(), IRustError> {
         if let Some(suggestion) = self.racer.as_ref()?.current_suggestion() {
-            if self.at_line_end() {
+            if self.cursor.is_at_line_end(&self) {
                 let mut suggestion = suggestion.0;
 
                 self.color
                     .set_fg(self.options.racer_inline_suggestion_color)?;
-                self.cursor.hide()?;
-                self.save_cursor_position()?;
+                self.cursor.hide();
+                self.cursor.save_position()?;
                 self.terminal.clear(ClearType::FromCursorDown)?;
 
                 StringTools::strings_unique(&self.buffer, &mut suggestion);
 
-                let overflow = self.screen_height_overflow_by_str(&suggestion);
+                let overflow = self.cursor.screen_height_overflow_by_str(&self, &suggestion);
 
                 self.write(&suggestion)?;
 
-                self.reset_cursor_position()?;
-                self.cursor.show()?;
+                self.cursor.reset_position()?;
+                self.cursor.show();
 
                 if overflow != 0 {
                     self.cursor.move_up(overflow as u16);
-                    self.internal_cursor.screen_pos.1 -= overflow;
+                    self.cursor.pos.screen_pos.1 -= overflow;
                 }
 
                 self.color.reset()?;
@@ -255,7 +255,7 @@ impl IRust {
     }
 
     pub fn cycle_suggestions(&mut self, cycle: Cycle) -> Result<(), IRustError> {
-        if self.at_line_end() {
+        if self.cursor.is_at_line_end(&self) {
             // Clear screen from cursor down
             self.terminal.clear(ClearType::FromCursorDown)?;
 
@@ -277,16 +277,16 @@ impl IRust {
             );
 
             // Handle screen height overflow
-            let height_overflow = self.screen_height_overflow_by_new_lines(suggestions_num + 1);
+            let height_overflow = self.cursor.screen_height_overflow_by_new_lines(&self, suggestions_num + 1);
             if height_overflow != 0 {
                 self.scroll_up(height_overflow);
             }
 
             // Save cursors postions from this point (Input position)
-            self.save_cursor_position()?;
+            self.cursor.save_position()?;
 
             // Write from screen start if a suggestion will be truncated
-            let mut max_width = self.size.0 - self.internal_cursor.screen_pos.0;
+            let mut max_width = self.size.0 - self.cursor.pos.screen_pos.0;
             if self
                 .racer
                 .as_ref()?
@@ -294,10 +294,10 @@ impl IRust {
                 .iter()
                 .any(|s| Racer::full_suggestion(s).len() > max_width)
             {
-                self.internal_cursor.screen_pos.0 = 0;
-                self.goto_cursor()?;
+                self.cursor.pos.screen_pos.0 = 0;
+                self.cursor.goto_internal_pos()?;
 
-                max_width = self.size.0 - self.internal_cursor.screen_pos.0;
+                max_width = self.size.0 - self.cursor.pos.screen_pos.0;
             }
 
             // Write the suggestions
@@ -335,7 +335,7 @@ impl IRust {
 
                 // move back to initial position
                 self.cursor.move_up(idx as u16 + 1);
-                self.cursor.move_left(suggestion.len() as u16);
+                self.cursor.move_left(suggestion.len() as u16)?;
 
                 // reset color in case of current suggestion
                 self.color.set_bg(crossterm::Color::Reset)?;
@@ -343,7 +343,7 @@ impl IRust {
 
             // reset to input position and color
             self.color.reset()?;
-            self.reset_cursor_position()?;
+            self.cursor.reset_position()?;
         }
 
         Ok(())
@@ -361,7 +361,7 @@ impl IRust {
             StringTools::strings_unique(&self.buffer, &mut suggestion);
 
             self.buffer.push_str(&suggestion);
-            self.internal_cursor.buffer_pos = StringTools::chars_count(&self.buffer);
+            self.cursor.pos.buffer_pos = StringTools::chars_count(&self.buffer);
 
             // clear screen from cursor down
             self.terminal.clear(ClearType::FromCursorDown)?;

--- a/src/irust/writer.rs
+++ b/src/irust/writer.rs
@@ -15,7 +15,7 @@ impl IRust {
             } else {
                 out.chars().for_each(|c| {
                     let _ = self.terminal.write(c);
-                    let _ = self.move_cursor_right();
+                    let _ = self.cursor.move_screen_cursor_right();
                 });
             }
         }
@@ -34,28 +34,29 @@ impl IRust {
         x: P,
         y: U,
     ) -> Result<(), IRustError> {
-        self.move_cursor_to(x, y)?;
+        self.cursor.move_cursor_to(x, y)?;
         self.terminal.write(s)?;
         Ok(())
     }
 
     pub fn write_newline(&mut self) -> Result<(), IRustError> {
-        self.internal_cursor.screen_pos.0 = 0;
-        self.internal_cursor.screen_pos.1 += 1;
-        self.internal_cursor.add_bounds();
+        self.cursor.pos.screen_pos.0 = 0;
+        self.cursor.pos.screen_pos.1 += 1;
+        self.cursor.add_bounds();
         // y should never exceed screen height
-        if self.internal_cursor.screen_pos.1 == self.size.1 {
+        if self.cursor.pos.screen_pos.1 == self.size.1 {
             self.scroll_up(1);
         }
-        self.goto_cursor()?;
+
+        self.cursor.goto_internal_pos()?;
         Ok(())
     }
 
     pub fn clear_suggestion(&mut self) -> Result<(), IRustError> {
-        if self.at_line_end() {
+        if self.cursor.is_at_line_end(&self) {
             self.clear_from(
-                self.internal_cursor.screen_pos.0,
-                self.internal_cursor.screen_pos.1,
+                self.cursor.pos.screen_pos.0,
+                self.cursor.pos.screen_pos.1,
             )?;
         }
 
@@ -68,7 +69,7 @@ impl IRust {
         y: U,
     ) -> Result<(), IRustError> {
         self.cursor.save_position()?;
-        self.move_cursor_to(x, y)?;
+        self.cursor.move_cursor_to(x, y)?;
         self.terminal.clear(ClearType::FromCursorDown)?;
         self.cursor.reset_position()?;
 
@@ -77,20 +78,20 @@ impl IRust {
 
     pub fn clear(&mut self) -> Result<(), IRustError> {
         self.terminal.clear(ClearType::All)?;
-        self.internal_cursor.reset();
-        self.internal_cursor.screen_pos.1 = 0;
-        self.goto_cursor()?;
+        self.cursor.reset();
+        self.cursor.pos.screen_pos.1 = 0;
+        self.cursor.goto_internal_pos()?;
 
         self.write_in()?;
         self.write(&self.buffer.clone())?;
-        self.internal_cursor.buffer_pos = StringTools::chars_count(&self.buffer);
+        self.cursor.pos.buffer_pos = StringTools::chars_count(&self.buffer);
 
         Ok(())
     }
 
     pub fn delete_char(&mut self) -> Result<(), IRustError> {
         if !self.buffer.is_empty() {
-            StringTools::remove_at_char_idx(&mut self.buffer, self.internal_cursor.buffer_pos);
+            StringTools::remove_at_char_idx(&mut self.buffer, self.cursor.pos.buffer_pos);
         }
         self.write_insert(None)?;
         Ok(())
@@ -99,8 +100,8 @@ impl IRust {
     pub fn scroll_up(&mut self, n: usize) {
         self.terminal.scroll_up(n as i16).unwrap();
         self.cursor.move_up(n as u16);
-        self.internal_cursor.screen_pos.1 = self.internal_cursor.screen_pos.1.saturating_sub(n);
-        self.internal_cursor.lock_pos.1 = self.internal_cursor.lock_pos.1.saturating_sub(n);
-        self.internal_cursor.bounds.shift_keys_left(n);
+        self.cursor.pos.screen_pos.1 = self.cursor.pos.screen_pos.1.saturating_sub(n);
+        self.cursor.pos.starting_pos.1 = self.cursor.pos.starting_pos.1.saturating_sub(n);
+        self.cursor.pos.bounds.shift_keys_left(n);
     }
 }


### PR DESCRIPTION
See title and commit message. Continuation of #43, fixing my rebase-related blunder.

~The code works AFAIK, only thing now is some tweaking of variable names and function definitions (see the comments in cursor.rs).~

@sigmaSd Rust says that `TerminalCursor::now()` is not a defined function. I don't think `Option::take()` works (or `mem::replace` AFAIK), since it 1) needs a mut ref to `Cursor` which `Clone` doesn't use, and 2) replaces `Cursor`'s value for `TerminalCursor` with `None`, which causes problems (and means it isn't technically cloning).