### PR TITLE
Run `cargo fmt` and add `rustfmt.toml`

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+max_width = 80

--- a/src/irust.rs
+++ b/src/irust.rs
@@ -1,5 +1,6 @@
 use crossterm::{
-    Crossterm, InputEvent, KeyEvent, Terminal, TerminalColor, TerminalCursor, TerminalInput,
+    Crossterm, InputEvent, KeyEvent, Terminal, TerminalColor, TerminalCursor,
+    TerminalInput,
 };
 
 mod art;
@@ -57,7 +58,8 @@ impl IRust {
         let color = crossterm.color();
         let buffer = String::new();
         let repl = Repl::new();
-        let history = History::new(dirs::cache_dir().unwrap().join("irust")).unwrap_or_default();
+        let history = History::new(dirs::cache_dir().unwrap().join("irust"))
+            .unwrap_or_default();
         let options = Options::new().unwrap_or_default();
         let debouncer = Debouncer::new();
         let racer = if options.enable_racer {

--- a/src/irust/art.rs
+++ b/src/irust/art.rs
@@ -71,7 +71,10 @@ impl IRust {
         self.terminal.clear(ClearType::All)?;
 
         let default_msg = "Welcome to IRust".to_string();
-        self.printer = Printer::new(PrinterItem::new(default_msg, PrinterItemType::Welcome));
+        self.printer = Printer::new(PrinterItem::new(
+            default_msg,
+            PrinterItemType::Welcome,
+        ));
         self.printer.add_new_line(2);
 
         self.write_out()?;

--- a/src/irust/cargo_cmds.rs
+++ b/src/irust/cargo_cmds.rs
@@ -9,7 +9,8 @@ use std::process::Command;
 
 pub static TMP_DIR: Lazy<PathBuf> = Lazy::new(temp_dir);
 pub static IRUST_DIR: Lazy<PathBuf> = Lazy::new(|| TMP_DIR.join("irust"));
-pub static MAIN_FILE: Lazy<PathBuf> = Lazy::new(|| IRUST_DIR.join("src/main.rs"));
+pub static MAIN_FILE: Lazy<PathBuf> =
+    Lazy::new(|| IRUST_DIR.join("src/main.rs"));
 
 pub fn cargo_new() -> Result<(), io::Error> {
     clean_toml();

--- a/src/irust/cursor.rs
+++ b/src/irust/cursor.rs
@@ -44,7 +44,8 @@ impl Cursor {
     fn move_right(&mut self) {
         if self.screen_pos.0 == self.current_upper_bound() {
             if self.bounds.contains(self.screen_pos.1 + 1) {
-                self.screen_pos.0 = self.bounds.lower_bound(self.screen_pos.1 + 1);
+                self.screen_pos.0 =
+                    self.bounds.lower_bound(self.screen_pos.1 + 1);
                 self.screen_pos.1 += 1;
             } else {
                 self.screen_pos.0 = 0;
@@ -62,7 +63,8 @@ impl Cursor {
         }
         if self.screen_pos.0 == self.current_lower_bound() {
             if self.bounds.contains(self.screen_pos.1 - 1) {
-                self.screen_pos.0 = self.bounds.upper_bound(self.screen_pos.1 - 1);
+                self.screen_pos.0 =
+                    self.bounds.upper_bound(self.screen_pos.1 - 1);
                 self.screen_pos.1 -= 1;
 
                 if move_type == Move::Modify {
@@ -153,10 +155,14 @@ impl IRust {
 
     pub fn at_line_end(&self) -> bool {
         self.buffer.is_empty()
-            || self.internal_cursor.buffer_pos == StringTools::chars_count(&self.buffer)
+            || self.internal_cursor.buffer_pos
+                == StringTools::chars_count(&self.buffer)
     }
 
-    pub fn move_cursor_left(&mut self, move_type: Move) -> Result<(), IRustError> {
+    pub fn move_cursor_left(
+        &mut self,
+        move_type: Move,
+    ) -> Result<(), IRustError> {
         self.internal_cursor.move_left(move_type);
         self.goto_cursor()?;
 
@@ -171,15 +177,20 @@ impl IRust {
     }
 
     pub fn screen_height_overflow_by_str(&self, out: &str) -> usize {
-        let new_lines =
-            (StringTools::chars_count(out) + self.internal_cursor.screen_pos.0) / self.size.0;
+        let new_lines = (StringTools::chars_count(out)
+            + self.internal_cursor.screen_pos.0)
+            / self.size.0;
 
         self.screen_height_overflow_by_new_lines(new_lines)
     }
 
-    pub fn screen_height_overflow_by_new_lines(&self, new_lines: usize) -> usize {
+    pub fn screen_height_overflow_by_new_lines(
+        &self,
+        new_lines: usize,
+    ) -> usize {
         // if corrected y  + new lines < self.size.1 there is no overflow so unwrap to 0
-        (new_lines + self.internal_cursor.screen_pos.1).saturating_sub(self.size.1)
+        (new_lines + self.internal_cursor.screen_pos.1)
+            .saturating_sub(self.size.1)
     }
 
     pub fn save_cursor_position(&mut self) -> Result<(), IRustError> {

--- a/src/irust/debouncer.rs
+++ b/src/irust/debouncer.rs
@@ -24,7 +24,9 @@ impl Debouncer {
         let send = self.send.clone();
         let timer = self.timer.clone();
         std::thread::spawn(move || loop {
-            if timer.lock().unwrap().elapsed() >= Duration::from_millis(WAIT_TIMEOUT) {
+            if timer.lock().unwrap().elapsed()
+                >= Duration::from_millis(WAIT_TIMEOUT)
+            {
                 send.send(1).unwrap();
             }
             std::thread::sleep(std::time::Duration::from_millis(SLEEP_TIME));

--- a/src/irust/events.rs
+++ b/src/irust/events.rs
@@ -16,7 +16,11 @@ impl IRust {
         }
 
         // Insert input char in buffer
-        StringTools::insert_at_char_idx(&mut self.buffer, self.internal_cursor.buffer_pos, c);
+        StringTools::insert_at_char_idx(
+            &mut self.buffer,
+            self.internal_cursor.buffer_pos,
+            c,
+        );
 
         // update histroy current
         self.history.update_current(&self.buffer);
@@ -57,7 +61,10 @@ impl IRust {
                 self.printer = out;
             }
             Err(e) => {
-                self.printer = Printer::new(PrinterItem::new(e.to_string(), PrinterItemType::Err));
+                self.printer = Printer::new(PrinterItem::new(
+                    e.to_string(),
+                    PrinterItemType::Err,
+                ));
             }
         }
 
@@ -87,7 +94,8 @@ impl IRust {
     }
 
     fn handle_incomplete_input(&mut self) -> Result<(), IRustError> {
-        self.internal_cursor.current_bounds_mut().1 = self.internal_cursor.screen_pos.0 - 1;
+        self.internal_cursor.current_bounds_mut().1 =
+            self.internal_cursor.screen_pos.0 - 1;
         self.internal_cursor.screen_pos.0 = 4;
         self.internal_cursor.screen_pos.1 += 1;
         if self.internal_cursor.screen_pos.1 == self.size.1 {
@@ -132,7 +140,8 @@ impl IRust {
             )?;
             self.terminal.clear(ClearType::FromCursorDown)?;
             self.buffer = up.clone();
-            self.internal_cursor.buffer_pos = StringTools::chars_count(&self.buffer);
+            self.internal_cursor.buffer_pos =
+                StringTools::chars_count(&self.buffer);
 
             let overflow = self.screen_height_overflow_by_str(&up);
 
@@ -159,7 +168,8 @@ impl IRust {
             )?;
             self.terminal.clear(ClearType::FromCursorDown)?;
             self.buffer = down.clone();
-            self.internal_cursor.buffer_pos = StringTools::chars_count(&self.buffer);
+            self.internal_cursor.buffer_pos =
+                StringTools::chars_count(&self.buffer);
 
             let overflow = self.screen_height_overflow_by_str(&down);
 
@@ -266,8 +276,8 @@ impl IRust {
 
     pub fn go_to_start(&mut self) -> Result<(), IRustError> {
         self.clear_suggestion()?;
-        let distance_to_start =
-            self.internal_cursor.screen_pos.0 - self.internal_cursor.current_bounds_mut().0;
+        let distance_to_start = self.internal_cursor.screen_pos.0
+            - self.internal_cursor.current_bounds_mut().0;
         if distance_to_start != 0 {
             self.cursor.move_left(distance_to_start as u16);
             self.internal_cursor.screen_pos.0 -= distance_to_start;
@@ -282,9 +292,10 @@ impl IRust {
             let _ = self.use_suggestion();
         } else {
             let distance_to_end = {
-                let c1 =
-                    self.internal_cursor.current_bounds_mut().1 - self.internal_cursor.screen_pos.0;
-                let c2 = StringTools::chars_count(&self.buffer) - self.internal_cursor.buffer_pos;
+                let c1 = self.internal_cursor.current_bounds_mut().1
+                    - self.internal_cursor.screen_pos.0;
+                let c2 = StringTools::chars_count(&self.buffer)
+                    - self.internal_cursor.buffer_pos;
                 std::cmp::min(c1, c2)
             };
             if distance_to_end != 0 {
@@ -309,7 +320,9 @@ impl IRust {
         let _ = self.move_cursor_left(Move::Free);
         self.internal_cursor.move_buffer_cursor_left();
 
-        if let Some(current_char) = buffer.get(self.internal_cursor.buffer_pos.checked_sub(1)?) {
+        if let Some(current_char) =
+            buffer.get(self.internal_cursor.buffer_pos.checked_sub(1)?)
+        {
             match *current_char {
                 ' ' => {
                     while buffer[self.internal_cursor.buffer_pos] == ' ' {
@@ -318,7 +331,9 @@ impl IRust {
                     }
                 }
                 c if c.is_alphanumeric() => {
-                    while buffer[self.internal_cursor.buffer_pos.checked_sub(1)?].is_alphanumeric()
+                    while buffer
+                        [self.internal_cursor.buffer_pos.checked_sub(1)?]
+                    .is_alphanumeric()
                     {
                         let _ = self.move_cursor_left(Move::Free);
                         self.internal_cursor.move_buffer_cursor_left();
@@ -326,8 +341,12 @@ impl IRust {
                 }
 
                 _ => {
-                    while !buffer[self.internal_cursor.buffer_pos.checked_sub(1)?].is_alphanumeric()
-                        && buffer[self.internal_cursor.buffer_pos.checked_sub(1)?] != ' '
+                    while !buffer
+                        [self.internal_cursor.buffer_pos.checked_sub(1)?]
+                    .is_alphanumeric()
+                        && buffer
+                            [self.internal_cursor.buffer_pos.checked_sub(1)?]
+                            != ' '
                     {
                         let _ = self.move_cursor_left(Move::Free);
                         self.internal_cursor.move_buffer_cursor_left();
@@ -346,10 +365,13 @@ impl IRust {
         } else {
             let _ = self.use_suggestion();
         }
-        if let Some(current_char) = buffer.get(self.internal_cursor.buffer_pos) {
+        if let Some(current_char) = buffer.get(self.internal_cursor.buffer_pos)
+        {
             match *current_char {
                 ' ' => {
-                    while buffer.get(self.internal_cursor.buffer_pos + 1) == Some(&' ') {
+                    while buffer.get(self.internal_cursor.buffer_pos + 1)
+                        == Some(&' ')
+                    {
                         let _ = self.move_cursor_right();
                         self.internal_cursor.move_buffer_cursor_right();
                     }
@@ -357,7 +379,9 @@ impl IRust {
                     self.internal_cursor.move_buffer_cursor_right();
                 }
                 c if c.is_alphanumeric() => {
-                    while let Some(character) = buffer.get(self.internal_cursor.buffer_pos) {
+                    while let Some(character) =
+                        buffer.get(self.internal_cursor.buffer_pos)
+                    {
                         if !character.is_alphanumeric() {
                             break;
                         }
@@ -367,7 +391,9 @@ impl IRust {
                 }
 
                 _ => {
-                    while let Some(character) = buffer.get(self.internal_cursor.buffer_pos) {
+                    while let Some(character) =
+                        buffer.get(self.internal_cursor.buffer_pos)
+                    {
                         if character.is_alphanumeric() || *character == ' ' {
                             break;
                         }

--- a/src/irust/format.rs
+++ b/src/irust/format.rs
@@ -12,7 +12,8 @@ pub fn format_eval_output(output: &str) -> Printer {
         let actual_error: String = if main_panic(&output) {
             // example:
             // thread 'main' panicked at 'attempt to multiply with overflow',
-            let mut output: Vec<&str> = output.lines().nth(3).unwrap().split(',').collect();
+            let mut output: Vec<&str> =
+                output.lines().nth(3).unwrap().split(',').collect();
             output.pop();
 
             output.join(",")
@@ -36,7 +37,8 @@ pub fn format_eval_output(output: &str) -> Printer {
             eval_output.add_new_line(1);
         }
 
-        eval_output.push(PrinterItem::new(output.into(), PrinterItemType::Eval));
+        eval_output
+            .push(PrinterItem::new(output.into(), PrinterItemType::Eval));
     }
 
     eval_output

--- a/src/irust/help.rs
+++ b/src/irust/help.rs
@@ -6,7 +6,9 @@ impl IRust {
     pub fn help(&mut self) -> Result<Printer, IRustError> {
         let mut outputs = Printer::default();
 
-        outputs.push("### Keywords / Tips & Tricks ###".to_output(Color::DarkYellow));
+        outputs.push(
+            "### Keywords / Tips & Tricks ###".to_output(Color::DarkYellow),
+        );
         outputs.push(
             "
 :help => print help

--- a/src/irust/highlight.rs
+++ b/src/irust/highlight.rs
@@ -7,7 +7,8 @@ use syntect::util::LinesWithEndings;
 
 static PS: Lazy<SyntaxSet> = Lazy::new(SyntaxSet::load_defaults_newlines);
 static TS: Lazy<ThemeSet> = Lazy::new(ThemeSet::load_defaults);
-static SYNTAX: Lazy<&SyntaxReference> = Lazy::new(|| PS.find_syntax_by_extension("rs").unwrap());
+static SYNTAX: Lazy<&SyntaxReference> =
+    Lazy::new(|| PS.find_syntax_by_extension("rs").unwrap());
 
 pub fn highlight(c: &str) -> Printer {
     let mut h = HighlightLines::new(&SYNTAX, &TS.themes["base16-ocean.dark"]);

--- a/src/irust/options.rs
+++ b/src/irust/options.rs
@@ -90,7 +90,9 @@ impl Options {
         Some(config_path)
     }
 
-    fn create_config(config_path: std::path::PathBuf) -> std::io::Result<Options> {
+    fn create_config(
+        config_path: std::path::PathBuf,
+    ) -> std::io::Result<Options> {
         let config = Options::default_config();
 
         let mut config_file = std::fs::File::create(&config_path)?;
@@ -137,7 +139,10 @@ impl Options {
         }
     }
 
-    fn get_section(lines: &[String], section_name: String) -> Vec<(String, String)> {
+    fn get_section(
+        lines: &[String],
+        section_name: String,
+    ) -> Vec<(String, String)> {
         let sec_start = match VecTools::index(lines, &section_name).get(0) {
             Some(idx) => *idx,
             None => {
@@ -154,7 +159,8 @@ impl Options {
         lines[sec_start + 1..sec_end]
             .iter()
             .filter_map(|line| {
-                let lines_part = line.split('=').map(str::trim).collect::<Vec<&str>>();
+                let lines_part =
+                    line.split('=').map(str::trim).collect::<Vec<&str>>();
                 if lines_part.len() == 2 {
                     Some((lines_part[0].to_string(), lines_part[1].to_string()))
                 } else {

--- a/src/irust/options/parser.rs
+++ b/src/irust/options/parser.rs
@@ -17,19 +17,25 @@ impl Options {
             .map(ToOwned::to_owned)
             .collect();
 
-        for (option, value) in Options::get_section(&lines, "[History]".to_string()).into_iter() {
+        for (option, value) in
+            Options::get_section(&lines, "[History]".to_string()).into_iter()
+        {
             match (option.to_lowercase().as_str(), value.clone()) {
                 ("add_irust_cmd_to_history", value) => {
-                    options.add_irust_cmd_to_history = Options::str_to_bool(&value);
+                    options.add_irust_cmd_to_history =
+                        Options::str_to_bool(&value);
                 }
                 ("add_shell_cmd_to_history", value) => {
-                    options.add_shell_cmd_to_history = Options::str_to_bool(&value);;
+                    options.add_shell_cmd_to_history =
+                        Options::str_to_bool(&value);
                 }
                 _ => eprintln!("Unknown config option: {} {}", option, value),
             }
         }
 
-        for (option, value) in Options::get_section(&lines, "[Colors]".to_string()).into_iter() {
+        for (option, value) in
+            Options::get_section(&lines, "[Colors]".to_string()).into_iter()
+        {
             match (option.to_lowercase().as_ref(), value.clone()) {
                 ("ok_color", value) => {
                     if let Ok(value) = Options::str_to_color(&value) {
@@ -80,7 +86,9 @@ impl Options {
             }
         }
 
-        for (option, value) in Options::get_section(&lines, "[Welcome]".to_string()).into_iter() {
+        for (option, value) in
+            Options::get_section(&lines, "[Welcome]".to_string()).into_iter()
+        {
             match (option.to_lowercase().as_str(), value.clone()) {
                 ("welcome_msg", value) => {
                     if !value.is_empty() {
@@ -96,7 +104,9 @@ impl Options {
             }
         }
 
-        for (option, value) in Options::get_section(&lines, "[Racer]".to_string()).into_iter() {
+        for (option, value) in
+            Options::get_section(&lines, "[Racer]".to_string()).into_iter()
+        {
             match (option.to_lowercase().as_str(), value.clone()) {
                 ("enable_racer", value) => {
                     options.enable_racer = Options::str_to_bool(&value);

--- a/src/irust/parser.rs
+++ b/src/irust/parser.rs
@@ -26,7 +26,10 @@ impl IRust {
 
     fn reset(&mut self) -> Result<Printer, IRustError> {
         self.repl.reset();
-        let mut outputs = Printer::new(PrinterItem::new(SUCCESS.to_string(), PrinterItemType::Ok));
+        let mut outputs = Printer::new(PrinterItem::new(
+            SUCCESS.to_string(),
+            PrinterItemType::Ok,
+        ));
         outputs.add_new_line(2);
 
         Ok(outputs)
@@ -34,7 +37,10 @@ impl IRust {
 
     fn pop(&mut self) -> Result<Printer, IRustError> {
         self.repl.pop();
-        let mut outputs = Printer::new(PrinterItem::new(SUCCESS.to_string(), PrinterItemType::Ok));
+        let mut outputs = Printer::new(PrinterItem::new(
+            SUCCESS.to_string(),
+            PrinterItemType::Ok,
+        ));
         outputs.add_new_line(2);
 
         Ok(outputs)
@@ -45,7 +51,10 @@ impl IRust {
             self.repl.del(line_num)?;
         }
 
-        let mut outputs = Printer::new(PrinterItem::new(SUCCESS.to_string(), PrinterItemType::Ok));
+        let mut outputs = Printer::new(PrinterItem::new(
+            SUCCESS.to_string(),
+            PrinterItemType::Ok,
+        ));
         outputs.add_new_line(2);
 
         Ok(outputs)
@@ -79,7 +88,10 @@ impl IRust {
         self.wait_add(self.repl.build()?, "Build")?;
         self.write_newline()?;
 
-        let mut outputs = Printer::new(PrinterItem::new(SUCCESS.to_string(), PrinterItemType::Ok));
+        let mut outputs = Printer::new(PrinterItem::new(
+            SUCCESS.to_string(),
+            PrinterItemType::Ok,
+        ));
         outputs.add_new_line(1);
 
         Ok(outputs)
@@ -97,7 +109,10 @@ impl IRust {
             self.repl.insert(s);
         }
 
-        let mut outputs = Printer::new(PrinterItem::new(SUCCESS.to_string(), PrinterItemType::Ok));
+        let mut outputs = Printer::new(PrinterItem::new(
+            SUCCESS.to_string(),
+            PrinterItemType::Ok,
+        ));
         outputs.add_new_line(1);
 
         Ok(outputs)
@@ -110,11 +125,13 @@ impl IRust {
         let variable = self.buffer.trim_start_matches(":type").to_string();
         let mut raw_out = String::new();
 
-        self.repl
-            .exec_in_tmp_repl(variable, || -> Result<(), IRustError> {
+        self.repl.exec_in_tmp_repl(
+            variable,
+            || -> Result<(), IRustError> {
                 raw_out = cargo_run(false).unwrap();
                 Ok(())
-            })?;
+            },
+        )?;
 
         let var_type = if raw_out.find(TYPE_FOUND_MSG).is_some() {
             raw_out
@@ -166,7 +183,8 @@ impl IRust {
             Ok(printer)
         } else {
             let mut outputs = Printer::default();
-            let mut eval_output = format_eval_output(&self.repl.eval(self.buffer.clone())?);
+            let mut eval_output =
+                format_eval_output(&self.repl.eval(self.buffer.clone())?);
 
             outputs.append(&mut eval_output);
             outputs.add_new_line(1);

--- a/src/irust/printer.rs
+++ b/src/irust/printer.rs
@@ -65,7 +65,9 @@ impl Iterator for Printer {
 }
 
 impl FromIterator<PrinterItem> for Printer {
-    fn from_iter<I: IntoIterator<Item = PrinterItem>>(printer_items: I) -> Self {
+    fn from_iter<I: IntoIterator<Item = PrinterItem>>(
+        printer_items: I,
+    ) -> Self {
         let mut printer = Printer::default();
         for printer_item in printer_items {
             printer.push(printer_item);

--- a/src/irust/racer.rs
+++ b/src/irust/racer.rs
@@ -190,10 +190,12 @@ impl IRust {
             // add +1 for the \t
             racer.cursor.1 = StringTools::chars_count(&self.buffer) + 1;
 
-            self.repl
-                .exec_in_tmp_repl(self.buffer.clone(), move || -> Result<(), IRustError> {
+            self.repl.exec_in_tmp_repl(
+                self.buffer.clone(),
+                move || -> Result<(), IRustError> {
                     racer.complete_code().map_err(From::from)
-                })?;
+                },
+            )?;
 
             // reset debouncer
             self.debouncer.reset_timer();
@@ -254,7 +256,10 @@ impl IRust {
         Ok(())
     }
 
-    pub fn cycle_suggestions(&mut self, cycle: Cycle) -> Result<(), IRustError> {
+    pub fn cycle_suggestions(
+        &mut self,
+        cycle: Cycle,
+    ) -> Result<(), IRustError> {
         if self.at_line_end() {
             // Clear screen from cursor down
             self.terminal.clear(ClearType::FromCursorDown)?;
@@ -277,7 +282,8 @@ impl IRust {
             );
 
             // Handle screen height overflow
-            let height_overflow = self.screen_height_overflow_by_new_lines(suggestions_num + 1);
+            let height_overflow =
+                self.screen_height_overflow_by_new_lines(suggestions_num + 1);
             if height_overflow != 0 {
                 self.scroll_up(height_overflow);
             }
@@ -311,7 +317,9 @@ impl IRust {
                 .suggestions
                 .iter()
                 .skip(
-                    ((self.racer.as_ref()?.suggestion_idx - 1) / suggestions_num) * suggestions_num,
+                    ((self.racer.as_ref()?.suggestion_idx - 1)
+                        / suggestions_num)
+                        * suggestions_num,
                 )
                 .take(suggestions_num)
                 .enumerate()
@@ -361,7 +369,8 @@ impl IRust {
             StringTools::strings_unique(&self.buffer, &mut suggestion);
 
             self.buffer.push_str(&suggestion);
-            self.internal_cursor.buffer_pos = StringTools::chars_count(&self.buffer);
+            self.internal_cursor.buffer_pos =
+                StringTools::chars_count(&self.buffer);
 
             // clear screen from cursor down
             self.terminal.clear(ClearType::FromCursorDown)?;

--- a/src/irust/repl.rs
+++ b/src/irust/repl.rs
@@ -47,7 +47,8 @@ impl Repl {
     }
 
     pub fn eval(&mut self, input: String) -> Result<String, IRustError> {
-        let eval_statement = format!("println!(\"{{:?}}\", {{\n{}\n}});", input);
+        let eval_statement =
+            format!("println!(\"{{:?}}\", {{\n{}\n}});", input);
         let mut eval_result = String::new();
 
         self.exec_in_tmp_repl(eval_statement, || -> Result<(), IRustError> {
@@ -58,7 +59,10 @@ impl Repl {
         Ok(eval_result)
     }
 
-    pub fn add_dep(&self, dep: &[String]) -> std::io::Result<std::process::Child> {
+    pub fn add_dep(
+        &self,
+        dep: &[String],
+    ) -> std::io::Result<std::process::Child> {
         Ok(cargo_add(dep)?)
     }
 

--- a/src/irust/writer.rs
+++ b/src/irust/writer.rs
@@ -83,14 +83,18 @@ impl IRust {
 
         self.write_in()?;
         self.write(&self.buffer.clone())?;
-        self.internal_cursor.buffer_pos = StringTools::chars_count(&self.buffer);
+        self.internal_cursor.buffer_pos =
+            StringTools::chars_count(&self.buffer);
 
         Ok(())
     }
 
     pub fn delete_char(&mut self) -> Result<(), IRustError> {
         if !self.buffer.is_empty() {
-            StringTools::remove_at_char_idx(&mut self.buffer, self.internal_cursor.buffer_pos);
+            StringTools::remove_at_char_idx(
+                &mut self.buffer,
+                self.internal_cursor.buffer_pos,
+            );
         }
         self.write_insert(None)?;
         Ok(())
@@ -99,8 +103,10 @@ impl IRust {
     pub fn scroll_up(&mut self, n: usize) {
         self.terminal.scroll_up(n as i16).unwrap();
         self.cursor.move_up(n as u16);
-        self.internal_cursor.screen_pos.1 = self.internal_cursor.screen_pos.1.saturating_sub(n);
-        self.internal_cursor.lock_pos.1 = self.internal_cursor.lock_pos.1.saturating_sub(n);
+        self.internal_cursor.screen_pos.1 =
+            self.internal_cursor.screen_pos.1.saturating_sub(n);
+        self.internal_cursor.lock_pos.1 =
+            self.internal_cursor.lock_pos.1.saturating_sub(n);
         self.internal_cursor.bounds.shift_keys_left(n);
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -46,7 +46,11 @@ pub fn remove_main(script: &str) -> String {
 pub struct StringTools {}
 
 impl StringTools {
-    pub fn insert_at_char_idx(buffer: &mut String, idx: usize, character: char) {
+    pub fn insert_at_char_idx(
+        buffer: &mut String,
+        idx: usize,
+        character: char,
+    ) {
         let mut buffer_chars: Vec<char> = buffer.chars().collect();
         buffer_chars.insert(idx, character);
         *buffer = buffer_chars.into_iter().collect();


### PR DESCRIPTION
Hopefully this is a welcome change that will keep IRust's code cleaner (if it isn't welcome I understand). 

This commit adds a `rustfmt.toml` file that specifies the max width for each line to be 80 characters (if we want more/less chars we can configure the max width, [and we can add other options too](https://rust-lang.github.io/rustfmt/)), and runs `cargo fmt --all` (see [here in the rustfmt README](https://github.com/rust-lang/rustfmt#on-the-stable-toolchain)) to format the codebase.

@sigmaSd If you like this PR (and after we make any changes you may want), could you please merge this prior to merging #44? I can then run `cargo fmt --all` on #44's branch before you merge it; that way I don't have to deal with fixing rebase conflicts xD.