### PR TITLE
issue49- showing ferris on :irust command

### DIFF
--- a/src/irust/art.rs
+++ b/src/irust/art.rs
@@ -90,6 +90,21 @@ impl IRust {
         Ok(())
     }
 
+    pub fn ferris(&mut self) -> String {        
+        let ferris = r#"
+     _~^~^~_
+ \) /  o o  \ (/
+   '_   ¬   _'
+   / '-----' \
+                     "#
+        .lines()
+        .skip(1)
+        .map(|l| l.to_string() + "\n")
+        .collect();
+
+        ferris
+    }
+
     fn fit_msg(&mut self, msg: &str) -> String {
         let slash_num = self.cursor.bound.width - msg.len();
         let slash = std::iter::repeat('-')

--- a/src/irust/parser.rs
+++ b/src/irust/parser.rs
@@ -5,6 +5,7 @@ use crate::irust::printer::{Printer, PrinterItem, PrinterItemType};
 use crate::irust::{IRust, IRustError};
 use crate::utils::{remove_main, stdout_and_stderr};
 
+
 const SUCCESS: &str = "Ok!";
 
 impl IRust {
@@ -211,17 +212,7 @@ impl IRust {
     }
 
     fn irust(&mut self) -> Result<Printer, IRustError> {
-        let irust = r#"
-._____________ ____ ___  ____________________
-|   \______   \    |   \/   _____/\__    ___/
-|   ||       _/    |   /\_____  \   |    |
-|   ||    |   \    |  / /        \  |    |
-|___||____|____\_____/ /_______  /  |____|
-                     "#
-        .lines()
-        .skip(1)
-        .map(|l| l.to_string() + "\n")
-        .collect();
+        let irust = self.ferris();
 
         Ok(Printer::new(PrinterItem::new(
             irust,


### PR DESCRIPTION
resolving https://github.com/sigmaSd/IRust/issues/49

Dear @sigmaSd 
1. The ascii art is moved to art.rs, the main print function stays where it was
2. I did not went for "random" idea (showing two different ferris by random) because it seems the project is not using anything random and "use crate::random" looks too much only for this fun usage. please tell me if you disagree