### PR TITLE
IRust finally compiles using crossterm 0.12.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/sigmaSd/IRust"
 license = "MIT"
 
 [dependencies]
-crossterm = "0.11.1"
+crossterm = "0.12.1"
 dirs = "2.0.2"
 once_cell = "1.2.0"
 


### PR DESCRIPTION
I could not simply do a `cargo install irust` nor clone the IRust repo and build it locally without encountering a bunch of errors all like this:

```Rust
   Compiling irust v0.7.20 (/Users/danielle/projects/IRust)
error[E0277]: `?` couldn't convert the error to `irust::irust_error::IRustError`
  --> src/irust.rs:87:60
   |
87 |         let _screen = crossterm::RawScreen::into_raw_mode()?;
   |                                                            ^ the trait `std::convert::From<crossterm_utils::error::ErrorKind>` is not implemented for `irust::irust_error::IRustError`
   |
   = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
   = help: the following implementations were found:
             <irust::irust_error::IRustError as std::convert::From<&irust::irust_error::IRustError>>
             <irust::irust_error::IRustError as std::convert::From<&mut irust::irust_error::IRustError>>
             <irust::irust_error::IRustError as std::convert::From<crossterm_utils::error::ErrorKind>>
             <irust::irust_error::IRustError as std::convert::From<std::io::Error>>
   = note: required by `std::convert::From::from`
```

Even trying 0.7.14 of IRust still led to the same errors. And so I assumed that there was something in the version of crossterm nominated in `Cargo.toml` that was perhaps not accounted for. Upping the version to 0.12.1 seemed to do the trick.

I'm hardly a Rust export, just a programming language enthusiast and so feel free to ignore this; I just wanted to capture what I did to get this to run.