### PR TITLE
Implement Autosync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,11 +94,11 @@ dependencies = [
  "crossterm_winapi",
  "lazy_static",
  "libc",
- "mio",
+ "mio 0.7.0",
  "parking_lot",
  "serde",
  "signal-hook",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -107,7 +107,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "057b7146d02fb50175fd7dbe5158f6097f33d02831f43b4ee8ae4ddf67b68f5c"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -128,8 +128,55 @@ checksum = "9c60f7b8a8953926148223260454befb50c751d3c50e1c178c4fd1ace4083c9a"
 dependencies = [
  "libc",
  "redox_users",
- "winapi",
+ "winapi 0.3.9",
 ]
+
+[[package]]
+name = "filetime"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed85775dcc68644b5c950ac06a2b23768d3bc9390464151aaf27136998dcf9e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "fsevent"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6"
+dependencies = [
+ "bitflags",
+ "fsevent-sys",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
+dependencies = [
+ "bitflags",
+ "fuchsia-zircon-sys",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "getrandom"
@@ -143,6 +190,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4816c66d2c8ae673df83366c18341538f234a26d65a9ecea5c348b453ac1d02f"
+dependencies = [
+ "bitflags",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e74a1aa87c59aeff6ef2cc2fa62d41bc43f54952f55652656b18a02fd5e356c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,15 +219,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "irust"
 version = "0.8.17"
 dependencies = [
  "crossterm",
  "dirs-next",
  "nix",
+ "notify",
  "once_cell",
  "serde",
  "toml",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
 ]
 
 [[package]]
@@ -168,6 +255,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -195,6 +288,25 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.6.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
+dependencies = [
+ "cfg-if",
+ "fuchsia-zircon",
+ "fuchsia-zircon-sys",
+ "iovec",
+ "kernel32-sys",
+ "libc",
+ "log",
+ "miow 0.2.1",
+ "net2",
+ "slab",
+ "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9971bc8349a361217a8f2a41f5d011274686bd4436465ba51730921039d7fb"
@@ -202,9 +314,33 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "miow",
+ "miow 0.3.5",
  "ntapi",
- "winapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "mio-extras"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
+dependencies = [
+ "lazycell",
+ "log",
+ "mio 0.6.22",
+ "slab",
+]
+
+[[package]]
+name = "miow"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+dependencies = [
+ "kernel32-sys",
+ "net2",
+ "winapi 0.2.8",
+ "ws2_32-sys",
 ]
 
 [[package]]
@@ -214,7 +350,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
 dependencies = [
  "socket2",
- "winapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "net2"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -230,12 +377,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify"
+version = "4.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80ae4a7688d1fab81c5bf19c64fc8db920be8d519ce6336ed4e7efe024724dbd"
+dependencies = [
+ "bitflags",
+ "filetime",
+ "fsevent",
+ "fsevent-sys",
+ "inotify",
+ "libc",
+ "mio 0.6.22",
+ "mio-extras",
+ "walkdir",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a31937dea023539c72ddae0e3571deadc1414b300483fa7aaec176168cfa9d2"
 dependencies = [
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -267,7 +432,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -318,6 +483,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,7 +524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604508c1418b99dfe1925ca9224829bb2a8a9a04dda655cc01fcad46f4ab05ed"
 dependencies = [
  "libc",
- "mio",
+ "mio 0.7.0",
  "signal-hook-registry",
 ]
 
@@ -363,6 +537,12 @@ dependencies = [
  "arc-swap",
  "libc",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
@@ -379,7 +559,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "winapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -409,10 +589,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
+name = "walkdir"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+dependencies = [
+ "same-file",
+ "winapi 0.3.9",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
@@ -425,13 +622,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+
+[[package]]
 name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "ws2_32-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+dependencies = [
+ "winapi 0.2.8",
+ "winapi-build",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ dirs-next = "1.0.1"
 once_cell = "1.4.1"
 toml = "0.5.6"
 serde = { version = "1.0.116", features = ["derive"] }
+notify = "4.0.15"
 
 [target.'cfg(unix)'.dependencies]
 nix = "0.18.0"

--- a/src/irust.rs
+++ b/src/irust.rs
@@ -96,163 +96,214 @@ impl IRust {
         enable_raw_mode()?;
         self.prepare()?;
 
+        let (tx, rx) = channel();
+        watch(tx.clone()).unwrap();
+        input_read(tx)?;
+
         loop {
             // flush queued output after each key
             // some events that have an inner input loop like ctrl-r/ ctrl-d require flushing inside their respective handler function
             self.raw_terminal.flush()?;
 
-            // handle input event
-            if let Ok(key_event) = read() {
-                match key_event {
-                    Event::Mouse(_) => (),
-                    Event::Resize(width, height) => {
-                        // ctrlc so we can ignore a lot of position adjusting
-                        // TODO fix this
-                        self.handle_ctrl_c()?;
-                        self.cursor = Cursor::new(width.into(), height.into());
-                    }
-                    Event::Key(key_event) => match key_event {
-                        KeyEvent {
-                            code: KeyCode::Char(c),
-                            modifiers: NO_MODIFIER,
-                        }
-                        | KeyEvent {
-                            code: KeyCode::Char(c),
-                            modifiers: SHIFT_KEYMODIFIER,
-                        } => {
-                            self.handle_character(c)?;
-                        }
-                        KeyEvent {
-                            code: KeyCode::Char('e'),
-                            modifiers: CTRL_KEYMODIFIER,
-                        } => {
-                            self.handle_ctrl_e()?;
-                        }
-                        KeyEvent {
-                            code: KeyCode::Enter,
-                            ..
-                        } => {
-                            self.handle_enter(false)?;
-                        }
-                        KeyEvent {
-                            code: KeyCode::Tab, ..
-                        } => {
-                            self.handle_tab()?;
-                        }
-                        KeyEvent {
-                            code: KeyCode::BackTab,
-                            ..
-                        } => {
-                            self.handle_back_tab()?;
-                        }
-                        KeyEvent {
-                            code: KeyCode::Left,
-                            modifiers: NO_MODIFIER,
-                        } => {
-                            self.handle_left()?;
-                        }
-                        KeyEvent {
-                            code: KeyCode::Right,
-                            modifiers: NO_MODIFIER,
-                        } => {
-                            self.handle_right()?;
-                        }
-                        KeyEvent {
-                            code: KeyCode::Up, ..
-                        } => {
-                            self.handle_up()?;
-                        }
-                        KeyEvent {
-                            code: KeyCode::Down,
-                            ..
-                        } => {
-                            self.handle_down()?;
-                        }
-                        KeyEvent {
-                            code: KeyCode::Backspace,
-                            ..
-                        } => {
-                            self.handle_backspace()?;
-                        }
-                        KeyEvent {
-                            code: KeyCode::Char('c'),
-                            modifiers: CTRL_KEYMODIFIER,
-                        } => {
-                            self.handle_ctrl_c()?;
-                        }
-                        KeyEvent {
-                            code: KeyCode::Char('d'),
-                            modifiers: CTRL_KEYMODIFIER,
-                        } => {
-                            self.handle_ctrl_d()?;
-                        }
-                        KeyEvent {
-                            code: KeyCode::Char('z'),
-                            modifiers: CTRL_KEYMODIFIER,
-                        } => {
-                            self.handle_ctrl_z()?;
-                        }
-                        KeyEvent {
-                            code: KeyCode::Char('l'),
-                            modifiers: CTRL_KEYMODIFIER,
-                        } => {
-                            self.handle_ctrl_l()?;
-                        }
-                        KeyEvent {
-                            code: KeyCode::Char('r'),
-                            modifiers: CTRL_KEYMODIFIER,
-                        } => {
-                            self.handle_ctrl_r()?;
-                        }
-                        KeyEvent {
-                            code: KeyCode::Char('\r'),
-                            modifiers: ALT_KEYMODIFIER,
-                        } => {
-                            self.handle_alt_enter()?;
-                        }
-                        KeyEvent {
-                            code: KeyCode::Home,
-                            ..
-                        } => {
-                            self.handle_home_key()?;
-                        }
-                        KeyEvent {
-                            code: KeyCode::End, ..
-                        } => {
-                            self.handle_end_key()?;
-                        }
-                        KeyEvent {
-                            code: KeyCode::Left,
-                            modifiers: CTRL_KEYMODIFIER,
-                        } => {
-                            self.handle_ctrl_left();
-                        }
-                        KeyEvent {
-                            code: KeyCode::Right,
-                            modifiers: CTRL_KEYMODIFIER,
-                        } => {
-                            self.handle_ctrl_right();
-                        }
-                        KeyEvent {
-                            code: KeyCode::Delete,
-                            ..
-                        } => {
-                            self.handle_del()?;
-                        }
-                        keyevent => {
-                            // Handle AltGr on windows
-                            if keyevent
-                                .modifiers
-                                .contains(CTRL_KEYMODIFIER | ALT_KEYMODIFIER)
-                            {
-                                if let KeyCode::Char(c) = keyevent.code {
-                                    self.handle_character(c)?;
-                                }
-                            }
-                        }
-                    },
+            match rx.recv() {
+                Ok(IRustEvent::Input(ev)) => {
+                    self.handle_input_event(ev)?;
                 }
+                Ok(IRustEvent::Notify(_ev)) => {
+                    self.sync()?;
+                }
+                Err(_e) => (),
             }
         }
     }
+
+    fn handle_input_event(&mut self, ev: crossterm::event::Event) -> Result<(), IRustError> {
+        // handle input event
+        match ev {
+            Event::Mouse(_) => (),
+            Event::Resize(width, height) => {
+                // ctrlc so we can ignore a lot of position adjusting
+                // TODO fix this
+                self.handle_ctrl_c()?;
+                self.cursor = Cursor::new(width.into(), height.into());
+            }
+            Event::Key(key_event) => match key_event {
+                KeyEvent {
+                    code: KeyCode::Char(c),
+                    modifiers: NO_MODIFIER,
+                }
+                | KeyEvent {
+                    code: KeyCode::Char(c),
+                    modifiers: SHIFT_KEYMODIFIER,
+                } => {
+                    self.handle_character(c)?;
+                }
+                KeyEvent {
+                    code: KeyCode::Char('e'),
+                    modifiers: CTRL_KEYMODIFIER,
+                } => {
+                    self.handle_ctrl_e()?;
+                }
+                KeyEvent {
+                    code: KeyCode::Enter,
+                    ..
+                } => {
+                    self.handle_enter(false)?;
+                }
+                KeyEvent {
+                    code: KeyCode::Tab, ..
+                } => {
+                    self.handle_tab()?;
+                }
+                KeyEvent {
+                    code: KeyCode::BackTab,
+                    ..
+                } => {
+                    self.handle_back_tab()?;
+                }
+                KeyEvent {
+                    code: KeyCode::Left,
+                    modifiers: NO_MODIFIER,
+                } => {
+                    self.handle_left()?;
+                }
+                KeyEvent {
+                    code: KeyCode::Right,
+                    modifiers: NO_MODIFIER,
+                } => {
+                    self.handle_right()?;
+                }
+                KeyEvent {
+                    code: KeyCode::Up, ..
+                } => {
+                    self.handle_up()?;
+                }
+                KeyEvent {
+                    code: KeyCode::Down,
+                    ..
+                } => {
+                    self.handle_down()?;
+                }
+                KeyEvent {
+                    code: KeyCode::Backspace,
+                    ..
+                } => {
+                    self.handle_backspace()?;
+                }
+                KeyEvent {
+                    code: KeyCode::Char('c'),
+                    modifiers: CTRL_KEYMODIFIER,
+                } => {
+                    self.handle_ctrl_c()?;
+                }
+                KeyEvent {
+                    code: KeyCode::Char('d'),
+                    modifiers: CTRL_KEYMODIFIER,
+                } => {
+                    self.handle_ctrl_d()?;
+                }
+                KeyEvent {
+                    code: KeyCode::Char('z'),
+                    modifiers: CTRL_KEYMODIFIER,
+                } => {
+                    self.handle_ctrl_z()?;
+                }
+                KeyEvent {
+                    code: KeyCode::Char('l'),
+                    modifiers: CTRL_KEYMODIFIER,
+                } => {
+                    self.handle_ctrl_l()?;
+                }
+                KeyEvent {
+                    code: KeyCode::Char('r'),
+                    modifiers: CTRL_KEYMODIFIER,
+                } => {
+                    self.handle_ctrl_r()?;
+                }
+                KeyEvent {
+                    code: KeyCode::Char('\r'),
+                    modifiers: ALT_KEYMODIFIER,
+                } => {
+                    self.handle_alt_enter()?;
+                }
+                KeyEvent {
+                    code: KeyCode::Home,
+                    ..
+                } => {
+                    self.handle_home_key()?;
+                }
+                KeyEvent {
+                    code: KeyCode::End, ..
+                } => {
+                    self.handle_end_key()?;
+                }
+                KeyEvent {
+                    code: KeyCode::Left,
+                    modifiers: CTRL_KEYMODIFIER,
+                } => {
+                    self.handle_ctrl_left();
+                }
+                KeyEvent {
+                    code: KeyCode::Right,
+                    modifiers: CTRL_KEYMODIFIER,
+                } => {
+                    self.handle_ctrl_right();
+                }
+                KeyEvent {
+                    code: KeyCode::Delete,
+                    ..
+                } => {
+                    self.handle_del()?;
+                }
+                keyevent => {
+                    // Handle AltGr on windows
+                    if keyevent
+                        .modifiers
+                        .contains(CTRL_KEYMODIFIER | ALT_KEYMODIFIER)
+                    {
+                        if let KeyCode::Char(c) = keyevent.code {
+                            self.handle_character(c)?;
+                        }
+                    }
+                }
+            },
+        }
+        Ok(())
+    }
+}
+use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+use std::sync::mpsc::channel;
+use std::sync::mpsc::Sender;
+use std::time::Duration;
+
+fn watch(tx: Sender<IRustEvent>) -> notify::Result<()> {
+    std::thread::spawn(move || loop {
+        let (local_tx, local_rx) = channel();
+        let mut watcher: RecommendedWatcher =
+            Watcher::new(local_tx, Duration::from_secs(2)).unwrap();
+
+        watcher
+            .watch(&*cargo_cmds::MAIN_FILE_EXTERN, RecursiveMode::Recursive)
+            .unwrap();
+
+        if let Ok(ev) = local_rx.recv() {
+            tx.send(IRustEvent::Notify(ev)).unwrap();
+        }
+    });
+    Ok(())
+}
+
+fn input_read(tx: Sender<IRustEvent>) -> Result<(), IRustError> {
+    std::thread::spawn(move || loop {
+        if let Ok(ev) = read() {
+            tx.send(IRustEvent::Input(ev)).unwrap();
+        }
+    });
+
+    Ok(())
+}
+
+enum IRustEvent {
+    Input(crossterm::event::Event),
+    Notify(notify::DebouncedEvent),
 }

--- a/src/irust/parser.rs
+++ b/src/irust/parser.rs
@@ -337,7 +337,7 @@ impl IRust {
         }
     }
 
-    fn sync(&mut self) -> Result<Printer, IRustError> {
+    pub fn sync(&mut self) -> Result<Printer, IRustError> {
         match self.repl.update_from_main_file() {
             Ok(_) => Ok(Printer::new(PrinterItem::new(
                 SUCCESS.to_string(),

--- a/src/irust/repl.rs
+++ b/src/irust/repl.rs
@@ -17,7 +17,20 @@ impl Repl {
     }
 
     pub fn update_from_main_file(&mut self) -> Result<(), IRustError> {
-        let main_file = std::fs::read_to_string(&*MAIN_FILE_EXTERN)?;
+        let mut try_n = 0;
+        let main_file = loop {
+            let main_file = std::fs::read_to_string(&*MAIN_FILE_EXTERN)?;
+            if !main_file.is_empty() || try_n > 1 {
+                break main_file;
+            } else {
+                // Some editors keep the file handle open
+                // Give them some time
+                // Note: why does read_to_string does not return an error??
+                use std::time::Duration;
+                std::thread::sleep(Duration::from_secs(1));
+                try_n += 1;
+            }
+        };
         let lines_num = main_file.lines().count();
         if lines_num < 2 {
             return Err(IRustError::Custom(

--- a/src/irust/repl.rs
+++ b/src/irust/repl.rs
@@ -23,9 +23,8 @@ impl Repl {
             if !main_file.is_empty() || try_n > 1 {
                 break main_file;
             } else {
-                // Some editors keep the file handle open
+                // Some editors trancuate the file before saving (exp: vscode)
                 // Give them some time
-                // Note: why does read_to_string does not return an error??
                 use std::time::Duration;
                 std::thread::sleep(Duration::from_secs(1));
                 try_n += 1;


### PR DESCRIPTION
Implements Autosync instead of the need of manually using `:sync` after each edit in external editor 

@fdncred, I'm pinging in you in case you want to test this feature, since its based on your idea.

The workflow is now like this:
1- :edit atom/code or manually open `$TEMP/irust/src/main_extern.rs`

Any changes to this file will immediately be reflected on irust (after saving)