### PR TITLE
Use a well-defined ABI and layout for `GlobalVariables`

### DIFF
--- a/src/irust/global_variables.rs
+++ b/src/irust/global_variables.rs
@@ -1,13 +1,4 @@
-use std::path::PathBuf;
-
-pub struct GlobalVariables {
-    current_working_dir: PathBuf,
-    previous_working_dir: PathBuf,
-    last_loaded_code_path: Option<PathBuf>,
-    /// last successful output
-    last_output: Option<String>,
-    pub operation_number: usize,
-}
+include!("script_template/types.rs");
 
 impl GlobalVariables {
     pub fn new() -> Self {

--- a/src/irust/script_template/types.rs
+++ b/src/irust/script_template/types.rs
@@ -3,15 +3,16 @@ use std::path::PathBuf;
 
 // the signature must be this
 /// Global IRust variables accessible to the script
+#[repr(C)]
 pub struct GlobalVariables {
     /// Current directory that IRust is in
-    pub current_working_dir: PathBuf,
+    pub current_working_dir: Box<PathBuf>,
     /// Previous directory that IRust was in, this current directory can change if the user uses the `:cd` command
-    pub previous_working_dir: PathBuf,
+    pub previous_working_dir: Box<PathBuf>,
     /// Last path to a rust file loaded with `:load` command
-    pub last_loaded_code_path: Option<PathBuf>,
+    pub last_loaded_code_path: Option<Box<PathBuf>>,
     /// Last successful printed output
-    pub last_output: Option<String>,
+    pub last_output: Option<Box<String>>,
     /// A variable that increases with each input/output cycle
     pub operation_number: usize,
 }


### PR DESCRIPTION
The current definition of `GlobalVariables` implicitly relies on the ABI and layout of a copy-pasted definition of `GlobalVariables` to remain stable / the same across compilations, and even across different compiler versions 😱 ⚠️  **This is not guaranteed**, and is very likely to eventually lead to unsound breakage when that happens.

Since the only way to easily imbue a `struct` with a stable layout is the `#[repr(C)]` annotation, we use that to fix the outermost issue.

Alas, the issue then recurses onto the `String` and `PathBuf` definitions (_e.g._, image `PathBuf` being added a private extra field, or `String` having its `.ptr, .len, .cap` fields reordered): I am currently suggesting they be `Box`-wrapped so as to, at the very least, provide a stable layout to `GlobalVariables`. But since the dereferences of such pointers may still break in the future, ideally, the tools of a crate specialized on tackling these problems such as https://docs.rs/abi_stable ought to be used, but a decent simpler replacement could be the usage of well-defined types such as [`repr_c::String`](https://docs.rs/safer-ffi/0.0.5/safer_ffi/string/struct.String.html) (at the cost of replacing `PathBuf`s with `String`s, _i.e._, not supporting non-UTF8 paths).