### PR TITLE
:edit with editor from EDITOR environment variable by default

### DIFF
--- a/crates/irust/README.md
+++ b/crates/irust/README.md
@@ -25,7 +25,7 @@ Cross Platform Rust Repl
 
 **:del** *<line_num>* => remove a specific line from repl code (line count starts at 1 from the first expression statement)
 
-**:edit** *\<editor\>* => edit internal buffer using an external editor, example: `:edit micro`, Note some gui terminal requires using `:sync` command after the edit (vscode)
+**:edit** *[editor]* => edit internal buffer using an external editor, example: `:edit micro`. If no editor is specified then the one from the EDITOR environment variable is used (if set). Note some gui terminal requires using `:sync` command after the edit (vscode)
 
 **:sync** sync the changes written after using :edit with a gui editor (vscode) to the repl
 

--- a/crates/irust/src/irust/parser.rs
+++ b/crates/irust/src/irust/parser.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::str::FromStr;
 use std::time::Instant;
 
@@ -447,7 +448,13 @@ impl IRust {
         // exp: :edit vi
         let editor: String = match self.buffer.to_string().split_whitespace().nth(1) {
             Some(ed) => ed.to_string(),
-            None => return Err("No editor specified".into()),
+            None => {
+                if let Ok(ed) = env::var("EDITOR") {
+                    ed
+                } else {
+                    return Err("No editor specified".into());
+                }
+            }
         };
 
         self.printer.writer.raw.write_with_color(


### PR DESCRIPTION
This change allows you to use `:edit` without a parameter if you have your default editor specified in the `EDITOR` environment variable. Saves a bit of typing.