### PR TITLE
use cargo-show-asm instead of cargo-asm

### DIFF
--- a/crates/irust/README.md
+++ b/crates/irust/README.md
@@ -41,7 +41,7 @@ You can try out IRust with no installation or setup (via Gitpod.io) by visiting 
 
 **:bench** => run `cargo bench`
 
-**:asm** *\<function\>* => shows assembly of the specified function, note that the function needs to be public, and there has to be no free standing statements/expressions (requires [cargo-asm](https://github.com/gnzlbg/cargo-asm))
+**:asm** *\<function\>* => shows assembly of the specified function, note that the function needs to be public, and there has to be no free standing statements/expressions (requires [cargo-show-asm](https://github.com/pacak/cargo-show-asm))
 
 **:executor** *\<executor\>* => set the executor to be used by IRust, available options are: `sync` `tokio` `async_std`, by  using an async executor, `await` becomes usable with no other modifications (requires [cargo-edit](https://github.com/killercup/cargo-edit) for async executors)
 

--- a/crates/irust/src/dependencies.rs
+++ b/crates/irust/src/dependencies.rs
@@ -101,11 +101,11 @@ pub fn warn_about_opt_deps(options: &mut Options) {
                 .status()?])
         }),
         Dep::new(
-            "cargo-asm",
-            "cargo-asm",
+            "cargo-show-asm",
+            "cargo-show-asm",
             "viewing functions assembly",
             &|| {
-                let cmd = ["cargo", "install", "cargo-asm"];
+                let cmd = ["cargo", "install", "cargo-show-asm"];
                 println!("{}", format!("Running: {:?}", cmd).magenta());
 
                 Ok(vec![process::Command::new(cmd[0])

--- a/crates/irust_repl/src/cargo_cmds.rs
+++ b/crates/irust_repl/src/cargo_cmds.rs
@@ -275,14 +275,19 @@ pub fn cargo_fmt(c: &str) -> std::io::Result<String> {
 
 pub fn cargo_asm(fnn: &str, toolchain: ToolChain) -> Result<String> {
     let mut cmd = Command::new("cargo");
-    Ok(stdout_and_stderr(
-        cargo_common(&mut cmd, "asm", toolchain)
-            .arg("--lib")
-            .arg(format!("irust_host_repl::{}", fnn))
-            .arg("--rust")
-            .output()?,
-    ))
+    let output = cargo_common(&mut cmd, "asm", toolchain)
+        .arg("--lib")
+        .arg(format!("irust_host_repl::{}", fnn))
+        .arg("--rust")
+        .output()?;
+    if !output.status.success() {
+        return Err(
+            (stdout_and_stderr(output)
+            + "\nMaybe you should make the function `pub`, see https://github.com/pacak/cargo-show-asm#my-function-isnt-there").into());
+    }
+    Ok(stdout_and_stderr(output))
 }
+
 pub fn cargo_expand(toolchain: ToolChain) -> Result<String> {
     let mut cmd = Command::new("cargo");
     let output = cargo_common(&mut cmd, "expand", toolchain)


### PR DESCRIPTION
`cargo-asm` is not maintained. See: <https://github.com/pacak/cargo-show-asm#what-about-cargo-asm>