### PR TITLE
support mix commands with rust codes

### DIFF
--- a/crates/irust/src/irust/parser.rs
+++ b/crates/irust/src/irust/parser.rs
@@ -19,6 +19,40 @@ use irust_repl::{cargo_cmds::*, EvalConfig, EvalResult, Executor, MainResult, To
 use printer::printer::{PrintQueue, PrinterItem};
 
 const SUCCESS: &str = "Ok!";
+const COMMANDS: [&str; 32] = [
+    ":reset",
+    ":show",
+    ":pop",
+    ":irust",
+    ":sync",
+    ":exit",
+    ":quit",
+    ":help",
+    "::",
+    ":edit",
+    ":add",
+    ":hard_load_crate",
+    ":hard_load",
+    ":load",
+    ":reload",
+    ":type",
+    ":del",
+    ":dbg",
+    ":color",
+    ":cd",
+    ":toolchain",
+    ":main_result",
+    ":check_statements",
+    ":time_release",
+    ":time",
+    ":bench",
+    ":asm",
+    ":executor",
+    ":evaluator",
+    ":scripts",
+    ":compile_time",
+    ":expand",
+];
 
 macro_rules! success {
     () => {{
@@ -37,6 +71,24 @@ macro_rules! print_queue {
 
         Ok(print_queue)
     }};
+}
+
+pub fn split_cmds(buffer: String) -> Vec<String> {
+    let mut new_buf = vec![];
+    let mut tmp_vec = vec![];
+    for line in buffer.lines() {
+        if line.is_empty() {
+            continue;
+        }
+        if COMMANDS.iter().any(|c| line.trim().starts_with(c)) {
+            new_buf.push(tmp_vec.join(""));
+            new_buf.push(line.trim().to_owned());
+            tmp_vec.clear();
+        } else {
+            tmp_vec.push(line);
+        }
+    }
+    new_buf
 }
 
 impl IRust {


### PR DESCRIPTION
for example:

```rust
In: pub fn test() {
In:     println!("test");
In: }
In:  :expand test
In: pub fn another -> usize {
In:     42
In: }
In: :asm another
```
before:
![before](https://user-images.githubusercontent.com/1318472/199430782-077157e9-aa93-4c58-9519-8403b0956e10.png)

after:
![after](https://user-images.githubusercontent.com/1318472/199430951-eb40489b-ede1-44c0-90c1-61614d9158fb.png)
