### PR TITLE
use `workspace.dependencies` for scripts

### DIFF
--- a/script_examples/Cargo.toml
+++ b/script_examples/Cargo.toml
@@ -8,3 +8,7 @@ members = [
     "./irust_animation",
     "./mixed_cmds"
 ]
+
+[workspace.dependencies]
+irust_api = { path = "../crates/irust_api/" }
+rscript = "0.17.0"

--- a/script_examples/fun/Cargo.toml
+++ b/script_examples/fun/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2021"
 
 [dependencies]
 dirs = "4.0.0"
-irust_api = { path = "../../crates/irust_api" }
-rscript = "0.17.0"
 serde = { version = "1.0.130", features = ["derive"] }
 toml = "0.5.8"
+
+irust_api.workspace = true
+rscript.workspace = true

--- a/script_examples/ipython/Cargo.toml
+++ b/script_examples/ipython/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-irust_api = { path = "../../crates/irust_api/" }
-rscript = "0.17.0"
+irust_api.workspace = true
+rscript.workspace = true

--- a/script_examples/irust_animation/Cargo.toml
+++ b/script_examples/irust_animation/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 
 [dependencies]
 crossterm = "0.25.0"
-irust_api = { path = "../../crates/irust_api/" }
-rscript = "0.17.0"
+irust_api.workspace = true
+rscript.workspace = true
 
 [lib]
 crate-type = ["cdylib"]

--- a/script_examples/irust_prompt/Cargo.toml
+++ b/script_examples/irust_prompt/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-irust_api = { path = "../../crates/irust_api/" }
-rscript = "0.17.0"
+irust_api.workspace = true
+rscript.workspace = true

--- a/script_examples/irust_vim_dylib/Cargo.toml
+++ b/script_examples/irust_vim_dylib/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-irust_api = { path = "../../crates/irust_api/" }
-rscript = "0.17.0"
+irust_api.workspace = true
+rscript.workspace = true
 
 [lib]
 crate-type = ["cdylib"]

--- a/script_examples/mixed_cmds/Cargo.toml
+++ b/script_examples/mixed_cmds/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-irust_api = { path = "../../crates/irust_api/" }
-rscript = "0.17.0"
+irust_api.workspace = true
+rscript.workspace = true


### PR DESCRIPTION
see https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table