### PR TITLE
fix FileNotFoundError when installing irust_kernel

### DIFF
--- a/crates/irust_repl/irust_kernel/irust_kernel/install.py
+++ b/crates/irust_repl/irust_kernel/irust_kernel/install.py
@@ -46,9 +46,21 @@ def install_my_kernel_spec(user=True, prefix=None, local_build=False):
             print('Fetching `irust` repo and compiling `Re` executable')
             subprocess.run(["git", "clone","--depth","1", "https://github.com/sigmasd/irust"],cwd=td)
             irust_repl_dir = os.path.join(td,"irust", "crates", "irust_repl")
-            subprocess.run(["cargo", "b", "--release", "--example", "re", "--target-dir",cargo_target_dir], cwd=irust_repl_dir)
-
-            src = os.path.join(irust_repl_dir, cargo_target_dir, "release", "examples", "re")
+            subprocess.run(
+                [
+                    "cargo",
+                    "b",
+                    "--release",
+                    "--example",
+                    "re",
+                    "--target-dir",
+                    cargo_target_dir,
+                    "--manifest-path",
+                    os.path.join(irust_repl_dir, "Cargo.toml"),
+                ]
+            )
+          
+            src = os.path.join(cargo_target_dir, "release", "examples", "re")
             dst = os.path.join(td, "re")
             shutil.copy2(src, dst)
             shutil.rmtree(os.path.join(td,"irust"))

--- a/crates/irust_repl/irust_kernel/irust_kernel/install.py
+++ b/crates/irust_repl/irust_kernel/irust_kernel/install.py
@@ -48,7 +48,7 @@ def install_my_kernel_spec(user=True, prefix=None, local_build=False):
             irust_repl_dir = os.path.join(td,"irust", "crates", "irust_repl")
             subprocess.run(["cargo", "b", "--release", "--example", "re", "--target-dir",cargo_target_dir], cwd=irust_repl_dir)
 
-            src = os.path.join(cargo_target_dir, "release", "examples", "re")
+            src = os.path.join(irust_repl_dir, cargo_target_dir, "release", "examples", "re")
             dst = os.path.join(td, "re")
             shutil.copy2(src, dst)
             shutil.rmtree(os.path.join(td,"irust"))


### PR DESCRIPTION
After looking into the crates/irust_repl/irust_kernel/irust_kernel/install.py, I found only a missing path `irust_repl_dir` while declaring `src = os.path.join(cargo_target_dir, "release", "examples", "re")` on line 51.
Since on line 49, set the cwd to `irust_repl_dir`.
So, I created this pull request to address #123 and the installation works perfectly.


