### PR TITLE
fix format_eval_output to respect eval_color setting

### DIFF
--- a/crates/irust/src/irust/format.rs
+++ b/crates/irust/src/irust/format.rs
@@ -1,3 +1,4 @@
+use crate::Options;
 use crossterm::style::Color;
 use printer::printer::{PrintQueue, PrinterItem};
 use std::sync::OnceLock;
@@ -95,6 +96,7 @@ pub fn format_err_printqueue(output: &str, show_warnings: bool, repl_name: &str)
 }
 
 pub fn format_eval_output(
+    options: &Options,
     status: std::process::ExitStatus,
     output: String,
     prompt: String,
@@ -110,8 +112,8 @@ pub fn format_eval_output(
     }
 
     let mut eval_output = PrintQueue::default();
-    eval_output.push(PrinterItem::String(prompt, Color::Red));
-    eval_output.push(PrinterItem::String(output, Color::White));
+    eval_output.push(PrinterItem::String(prompt, options.out_color));
+    eval_output.push(PrinterItem::String(output, options.eval_color));
     eval_output.add_new_line(new_lines_after_output);
     Some(eval_output)
 }

--- a/crates/irust/src/irust/parser.rs
+++ b/crates/irust/src/irust/parser.rs
@@ -499,6 +499,7 @@ impl IRust {
 
             let output_prompt = self.get_output_prompt();
             if let Some(mut eval_output) = format_eval_output(
+                &self.options,
                 status,
                 output,
                 output_prompt,
@@ -666,6 +667,7 @@ impl IRust {
         let output_prompt = self.get_output_prompt();
         // safe unwrap
         Ok(format_eval_output(
+            &self.options,
             status.unwrap(),
             raw_out,
             output_prompt,


### PR DESCRIPTION
Remove the hardcoded Color::White value in format_eval_output.

Before 
![screenshot2025-04-17_20:07:47](https://github.com/user-attachments/assets/69eb0ade-d7a4-4759-bb3a-ca3d56624829)
After 
![screenshot2025-04-17_20:08:11](https://github.com/user-attachments/assets/0749eeb0-ce85-45df-8e50-eaeacbb09639)
